### PR TITLE
CM Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /coverage
 /data-dictionary
 /data-dictionary-integration
+/extensions
 /rules
 /step-models
 /ancestry-util.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,4 +60,8 @@ gulp.task('clean', finish => {
 
 gulp.task('build', ['clean', 'js', 'css'])
 
+gulp.task('watch', () => {
+  gulp.watch('src/**/*.js', ['build'])
+})
+
 gulp.task('default', ['build'])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuali-cor-workflows-common",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Workflows code common to both client and server",
   "author": "Kuali Core Team",
   "license": "SEE LICENSE IN LICENSE",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "gulp",
     "prepublish": "npm test && npm run build",
     "test": "standard --parser babel-eslint && jest",
+    "test:jest:watch": "jest --watch",
     "watch": "gulp watch"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "clean": "gulp clean",
     "build": "gulp",
     "prepublish": "npm test && npm run build",
-    "test": "standard --parser babel-eslint && jest"
+    "test": "standard --parser babel-eslint && jest",
+    "watch": "gulp watch"
   },
   "repository": {
     "type": "git",

--- a/src/api/group.js
+++ b/src/api/group.js
@@ -12,7 +12,7 @@ export default class GroupAPI extends api {
   static API_KEY = 'groups'
   static GROUP_API = '/api/v1/groups'
 
-  async list (q = { limit: 10 }) {
+  async list (q = { limit: 200 }) {
     const query = qs.encode(q)
     return this._get(`${GroupAPI.GROUP_API}?${query}`)
   }

--- a/src/api/group.js
+++ b/src/api/group.js
@@ -12,7 +12,7 @@ export default class GroupAPI extends api {
   static API_KEY = 'groups'
   static GROUP_API = '/api/v1/groups'
 
-  async list (q = { limit: 200 }) {
+  async list (q = { limit: 2000 }) {
     const query = qs.encode(q)
     return this._get(`${GroupAPI.GROUP_API}?${query}`)
   }

--- a/src/api/group.spec.js
+++ b/src/api/group.spec.js
@@ -22,7 +22,7 @@ describe('Group', () => {
 
   test('list with a query', async () => {
     await group.list()
-    expect(group._get).toHaveBeenCalledWith(`${Group.GROUP_API}?limit=10`)
+    expect(group._get).toHaveBeenCalledWith(`${Group.GROUP_API}?limit=2000`)
   })
 
   test('get', async () => {

--- a/src/data-dictionary-integration/workflow-context.js
+++ b/src/data-dictionary-integration/workflow-context.js
@@ -76,7 +76,7 @@ export default class WorkflowContext extends Context {
     const { context, parent } = this
     if (parent) await parent.getValue(valueMap)
 
-    const value = getValueFromExt(this, context, valueMap)
+    const value = await getValueFromExt(this, context, valueMap)
     if (value) return value
 
     switch (context.type) {

--- a/src/data-dictionary-integration/workflow-context.js
+++ b/src/data-dictionary-integration/workflow-context.js
@@ -107,7 +107,10 @@ export default class WorkflowContext extends Context {
     const data = {
       ...responses,
       definitionStep,
-      instanceStep
+      instanceStep,
+      formUrl: `/cor/forms/#/i/${responses.container._id}/view/${responses
+        .document._id}`,
+      handlerUrl: '/cor/appbuilder/#/run/{{ID}}'
     }
     valueMap.formfill = data
     return data

--- a/src/data-dictionary-integration/workflow-context.js
+++ b/src/data-dictionary-integration/workflow-context.js
@@ -10,6 +10,7 @@ import Promise from 'bluebird'
 import Context from '../data-dictionary/context'
 import { ALL } from '../data-dictionary/return-types'
 import Ancestry from '../ancestry-util'
+import { getValue as getValueFromExt } from '../extensions'
 
 const i18n = {
   MISSING_DATA:
@@ -74,6 +75,10 @@ export default class WorkflowContext extends Context {
   async getValue (valueMap = {}) {
     const { context, parent } = this
     if (parent) await parent.getValue(valueMap)
+
+    const value = getValueFromExt(this, context, valueMap)
+    if (value) return value
+
     switch (context.type) {
       case 'formfill':
         return this.getFormfillValue(context, valueMap)

--- a/src/data-dictionary/context-utils.js
+++ b/src/data-dictionary/context-utils.js
@@ -47,6 +47,7 @@ import formAPI from '../api/form'
 import groupAPI from '../api/group'
 import userAPI from '../api/user'
 import { ALL } from './return-types'
+import { contexts as additionalContexts, apis as additionalApis } from '../extensions'
 
 const i18n = {
   UNSUPPORTED_TYPE: 'Cannot getContextType of a non-deflated context'
@@ -82,7 +83,7 @@ export const contexts = [
   FieldTextInput,
   TextInput,
   NumericInput
-]
+].concat(additionalContexts)
 
 export const apis = [
   categoryAPI,
@@ -91,7 +92,7 @@ export const apis = [
   formAPI,
   groupAPI,
   userAPI
-]
+].concat(additionalApis)
 
 export const DEFAULT_SCOPE = {
   axios,

--- a/src/data-dictionary/context-utils.js
+++ b/src/data-dictionary/context-utils.js
@@ -5,7 +5,7 @@
  * You should have received a copy of the Kuali, Inc. Pre-Release License
  * Agreement with this file. If not, please write to license@kuali.co.
  */
-import { isArray, keyBy, last } from 'lodash'
+import { get, isArray, keyBy, last } from 'lodash'
 import axios from 'axios'
 import Context from './context'
 import Root from './root'
@@ -176,7 +176,8 @@ export class ContextUtil {
   async inflate (deflated, returnTypes = '*') {
     const { scope } = this
     const contexts = []
-    for (let i = 0; i < deflated.length; i++) {
+    const length = get(deflated, 'length', 0)
+    for (let i = 0; i < length; i++) {
       const defd = deflated[i]
       const parent = i > 0 ? contexts[i - 1] : undefined
       const Context = this.contextMap[defd.type]

--- a/src/data-dictionary/context-utils.js
+++ b/src/data-dictionary/context-utils.js
@@ -175,20 +175,12 @@ export class ContextUtil {
    */
   async inflate (deflated, returnTypes = '*') {
     const { scope } = this
-    const promises = deflated.map(d => {
-      if (d.requiresParent) return
-      return this.contextMap[d.type].inflate(this, d, undefined, scope)
-    })
-    const datas = await Promise.all(promises)
     const contexts = []
-    for (let i = 0; i < datas.length; i++) {
+    for (let i = 0; i < deflated.length; i++) {
       const defd = deflated[i]
-      let data = datas[i]
-      const Context = this.contextMap[defd.type]
       const parent = i > 0 ? contexts[i - 1] : undefined
-      if (defd.requiresParent) {
-        data = datas[i] = await Context.inflate(this, defd, parent, scope)
-      }
+      const Context = this.contextMap[defd.type]
+      let data = await Context.inflate(this, defd, parent, scope)
       const ctx = Context.type === this.Root.type
         ? this.root || new Root(parent, returnTypes, data, this)
         : new Context(parent, returnTypes, data, this)

--- a/src/data-dictionary/context-utils.spec.js
+++ b/src/data-dictionary/context-utils.spec.js
@@ -52,7 +52,7 @@ describe('Data Dictionary > Util', () => {
   })
 
   test('has a complete list of contexts', async () => {
-    expect(ctx.contexts).toHaveLength(29)
+    expect(ctx.contexts.length).toBeGreaterThanOrEqual(29)
     expect(ctx.contexts.find(c => c.type === Root.type)).toBe(Root)
     expect(ctx.contexts.find(c => c.type === GlobalCategories.type)).toBe(
       GlobalCategories

--- a/src/data-dictionary/global-groups/group.js
+++ b/src/data-dictionary/global-groups/group.js
@@ -7,6 +7,7 @@
  */
 import Context from '../context'
 import Category from '../global-categories/category'
+import Role from '../global-roles/role'
 import { CATEGORY, GROUP, ROLE, TEXT, USER } from '../return-types'
 
 export default class Group extends Context {
@@ -29,7 +30,7 @@ export default class Group extends Context {
     const parent = resp[0]
     const category = resp[1]
     const roles = await this.getGroupRoles(category)
-    const children = [category, ...roles]
+    const children = category ? [category].concat(roles) : roles
     if (parent) children.unshift(parent)
     return children
   }
@@ -49,6 +50,11 @@ export default class Group extends Context {
   }
 
   async getGroupRoles (category) {
+    if (this.data.roleSchemas) {
+      return this.data.roleSchemas.map(
+        role => new Role(this, this.returnTypes, role, this.ctx)
+      )
+    }
     const cat = category || (await this.getGroupCategory())
     if (!cat) return
     const roles = await category.getChildren()

--- a/src/data-dictionary/global-groups/group.js
+++ b/src/data-dictionary/global-groups/group.js
@@ -65,7 +65,7 @@ export default class Group extends Context {
   }
 
   static async inflate (ctx, deflated) {
-    return deflated
+    return deflated.data
   }
 
   deflate (valueList = []) {

--- a/src/data-dictionary/global-groups/group.js
+++ b/src/data-dictionary/global-groups/group.js
@@ -58,6 +58,18 @@ export default class Group extends Context {
     return roles
   }
 
+  static async inflate (ctx, deflated) {
+    return deflated
+  }
+
+  deflate (valueList = []) {
+    const { parent, type, name, data } = this
+    if (parent) parent.deflate(valueList)
+    // TODO: Should probably actually deflate instead of saving all data
+    valueList.push({ type, name, data, requiresParent: true })
+    return valueList
+  }
+
   isLeaf () {
     if (!this.data) return true
     return false

--- a/src/data-dictionary/global-groups/group.js
+++ b/src/data-dictionary/global-groups/group.js
@@ -80,4 +80,9 @@ export default class Group extends Context {
     if (!this.data) return true
     return false
   }
+
+  async getValue (valueMap = {}) {
+    super.getValue(valueMap)
+    valueMap.groupId = this.data.id
+  }
 }

--- a/src/data-dictionary/global-groups/index.spec.js
+++ b/src/data-dictionary/global-groups/index.spec.js
@@ -42,7 +42,7 @@ describe('Global groups contexts', () => {
   })
 
   test('can get group by return type', async () => {
-    mock.onGet('/api/v1/groups?limit=10').reply(200, GROUPS_RESPONSE)
+    mock.onGet('/api/v1/groups?limit=2000').reply(200, GROUPS_RESPONSE)
     const contexts = await ctx.getRoot().getChildren()
     const groups = contexts.find(
       ctx => ctx.constructor.type === GlobalGroups.type

--- a/src/data-dictionary/global-roles/role.js
+++ b/src/data-dictionary/global-roles/role.js
@@ -5,7 +5,6 @@
  * You should have received a copy of the Kuali, Inc. Pre-Release License
  * Agreement with this file. If not, please write to license@kuali.co.
  */
-import { get, last } from 'lodash'
 import Context from '../context'
 import { ROLE, TEXT, USER } from '../return-types'
 
@@ -20,10 +19,7 @@ export default class Role extends Context {
     const role = children.find(child =>
       child.type === Role.type && child.data.id === deflated.id
     )
-    const parentData = parent.deflate()
-    const formKey = parentData.length ? last(parentData).formKey : undefined
-    const groupId = parentData.length ? get(last(parentData), 'data.id') : undefined
-    return {...role.data, formKey, groupId}
+    return role.data
   }
 
   constructor (parent, returnTypes, data, ctx) {
@@ -46,6 +42,7 @@ export default class Role extends Context {
     const { data, parent } = this
     if (parent) await parent.getValue(valueMap)
     valueMap.role = { value: data }
-    return data
+    const { formKey, groupId } = valueMap
+    return {...data, formKey, groupId}
   }
 }

--- a/src/data-dictionary/global-roles/role.js
+++ b/src/data-dictionary/global-roles/role.js
@@ -5,7 +5,7 @@
  * You should have received a copy of the Kuali, Inc. Pre-Release License
  * Agreement with this file. If not, please write to license@kuali.co.
  */
-import { last } from 'lodash'
+import { get, last } from 'lodash'
 import Context from '../context'
 import { ROLE, TEXT, USER } from '../return-types'
 
@@ -22,7 +22,8 @@ export default class Role extends Context {
     )
     const parentData = parent.deflate()
     const formKey = parentData.length ? last(parentData).formKey : undefined
-    return {...role.data, formKey}
+    const groupId = parentData.length ? get(last(parentData), 'data.id') : undefined
+    return {...role.data, formKey, groupId}
   }
 
   constructor (parent, returnTypes, data, ctx) {

--- a/src/data-dictionary/global-roles/role.js
+++ b/src/data-dictionary/global-roles/role.js
@@ -5,6 +5,7 @@
  * You should have received a copy of the Kuali, Inc. Pre-Release License
  * Agreement with this file. If not, please write to license@kuali.co.
  */
+import { last } from 'lodash'
 import Context from '../context'
 import { ROLE, TEXT, USER } from '../return-types'
 
@@ -19,7 +20,9 @@ export default class Role extends Context {
     const role = children.find(child =>
       child.type === Role.type && child.data.id === deflated.id
     )
-    return role.data
+    const parentData = parent.deflate()
+    const formKey = parentData.length ? last(parentData).formKey : undefined
+    return {...role.data, formKey}
   }
 
   constructor (parent, returnTypes, data, ctx) {

--- a/src/data-dictionary/global-users/user.js
+++ b/src/data-dictionary/global-users/user.js
@@ -5,6 +5,7 @@
  * You should have received a copy of the Kuali, Inc. Pre-Release License
  * Agreement with this file. If not, please write to license@kuali.co.
  */
+import { get } from 'lodash'
 import Context from '../context'
 import { TEXT, USER } from '../return-types'
 
@@ -20,7 +21,7 @@ export default class User extends Context {
 
   constructor (parent, returnTypes, data, ctx) {
     super(parent, returnTypes, data, ctx)
-    this.name = data.displayName
+    this.name = get(data, 'displayName') || 'User Not Found'
   }
 
   getChildren = async () => []

--- a/src/data-dictionary/return-types.js
+++ b/src/data-dictionary/return-types.js
@@ -5,6 +5,7 @@
  * You should have received a copy of the Kuali, Inc. Pre-Release License
  * Agreement with this file. If not, please write to license@kuali.co.
  */
+import { returnTypes } from '../extensions/return-types'
 
 export const BOOLEAN = 'boolean'
 export const CATEGORY = 'category'
@@ -16,3 +17,5 @@ export const SUBFLOW = 'subflow'
 export const TEXT = 'text'
 export const USER = 'user'
 export const ALL = '*'
+
+export const ALLFORMS = [FORM].concat(returnTypes.forms)

--- a/src/data-dictionary/root/index.js
+++ b/src/data-dictionary/root/index.js
@@ -12,6 +12,7 @@ import GlobalForms from '../global-forms'
 import GlobalUsers from '../global-users'
 import TextInput from '../global-inputs/text-input'
 import NumericInput from '../global-inputs/numeric-input'
+import { rootContexts as additionalContexts } from '../../extensions'
 import { ALL } from '../return-types'
 
 export default class RootContext extends Context {
@@ -31,7 +32,7 @@ export default class RootContext extends Context {
       { type: GlobalUsers },
       { type: TextInput },
       { type: NumericInput }
-    ]
+    ].concat(additionalContexts)
   }
 
   /**

--- a/src/data-dictionary/root/index.spec.js
+++ b/src/data-dictionary/root/index.spec.js
@@ -16,7 +16,7 @@ describe('Root context', () => {
     test('can get contexts', async () => {
       const root = new Root(null, '*')
       const contexts = await root.getChildren()
-      expect(contexts).toHaveLength(6)
+      expect(contexts.length).toBeGreaterThanOrEqual(6)
     })
 
     test('can get contexts by return type', async () => {

--- a/src/extensions/api/cm.js
+++ b/src/extensions/api/cm.js
@@ -1,0 +1,29 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import api from '../../api/api'
+
+export default class CmAPI extends api {
+  static API_KEY = 'cm'
+  static CM_API = '/api/cm'
+
+  async institution () {
+    return this._get(`${CmAPI.CM_API}/institution`)
+  }
+
+  async settings () {
+    return this._get(`${CmAPI.CM_API}/settings`)
+  }
+
+  async schema (itemType) {
+    return this._get(`${CmAPI.CM_API}/${itemType}/schema`)
+  }
+
+  async getItem (itemType, itemId) {
+    return this._get(`${CmAPI.CM_API}/${itemType}/${itemId}`)
+  }
+}

--- a/src/extensions/api/cm.spec.js
+++ b/src/extensions/api/cm.spec.js
@@ -1,0 +1,48 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+import CM from './cm'
+
+describe('CM API', () => {
+  let cm
+  beforeEach(() => {
+    cm = new CM()
+  })
+
+  it('should call get on a single url for institution', async () => {
+    cm._get = jest.fn()
+    await cm.institution()
+    expect(cm._get).toHaveBeenCalledWith(
+      `${CM.CM_API}/institution`
+    )
+  })
+
+  it('should call get on a single url for settings', async () => {
+    cm._get = jest.fn()
+    await cm.settings()
+    expect(cm._get).toHaveBeenCalledWith(
+      `${CM.CM_API}/settings`
+    )
+  })
+
+  it('should call get on a single url for schema', async () => {
+    cm._get = jest.fn()
+    await cm.schema('courses')
+    expect(cm._get).toHaveBeenCalledWith(
+      `${CM.CM_API}/courses/schema`
+    )
+  })
+
+  it('should call get on a single url for getItem', async () => {
+    cm._get = jest.fn()
+    await cm.getItem('courses', '123')
+    expect(cm._get).toHaveBeenCalledWith(
+      `${CM.CM_API}/courses/123`
+    )
+  })
+})

--- a/src/extensions/config.js
+++ b/src/extensions/config.js
@@ -1,0 +1,24 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+module.exports = {
+  apis: {
+    cm: {
+      serviceAgent: {
+        secret: '4439ew8uf23weausdfljho4iuweahfs7023das',
+        expire: 60,
+        header: 'Authorization',
+        tokenPrefix: 'Bearer ',
+        disableSingleUse: true
+      },
+      protocol: 'https',
+      host: 'kuali.co',
+      forms: { v0: '/api/cm' }
+    }
+  }
+}

--- a/src/extensions/contexts/cm-forms/field-checkbox.js
+++ b/src/extensions/contexts/cm-forms/field-checkbox.js
@@ -1,0 +1,16 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import CMField from './field'
+import { BOOLEAN } from '../../../data-dictionary/return-types'
+
+export default class CMFieldCheckbox extends CMField {
+  static fieldType = 'Checkbox'
+  static type = 'cm-field-checkbox'
+  static returnTypes = [BOOLEAN]
+  static matchTypes = [BOOLEAN]
+}

--- a/src/extensions/contexts/cm-forms/field-core-group-multiselect.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-multiselect.js
@@ -1,0 +1,62 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import CMField from './field'
+import Category from '../../../data-dictionary/global-categories/category'
+import Role from '../../../data-dictionary/global-roles/role'
+import { GROUP, TEXT } from '../../../data-dictionary/return-types'
+
+export default class FieldCoreGroupMultiselect extends CMField {
+  static fieldType = 'GroupsMultiselect'
+  static type = 'cm-field-core-group-multiselect'
+  static returnTypes = [GROUP, TEXT]
+  static matchTypes = [GROUP, TEXT]
+
+  static async inflate (ctx, deflated, parent) {
+    return deflated.data
+  }
+
+  getChildren = async filter => {
+    const { categoryId } = this.data
+    const category = await this.ctx.apis.categories.get(categoryId)
+    const { parentId, roleSchemas } = category
+    const children = roleSchemas.map(
+      role => new Role(this, this.returnTypes, role, this.ctx)
+    )
+    if (parentId) {
+      const pData = await this.ctx.apis.categories.get(parentId)
+      children.unshift(new Category(this, this.returnTypes, pData, this.ctx))
+    }
+    return children
+  }
+
+  isLeaf = () => false
+
+  deflate (valueList = []) {
+    const { parent, type, name, data } = this
+    if (parent) parent.deflate(valueList)
+    valueList.push({
+      type,
+      name,
+      data,
+      formKey: data.formKey,
+      requiresParent: false
+    })
+    return valueList
+  }
+
+  async getValue (valueMap = {}) {
+    const { data, parent } = this
+    if (parent) await parent.getValue(valueMap)
+    if (!valueMap.formfill || !valueMap.formfill.document) return
+    const { document } = valueMap.formfill
+    const groupId = document.data[data.formKey].id
+    const group = await this.ctx.apis.groups.get(groupId)
+    valueMap.field = { value: group }
+    return group
+  }
+}

--- a/src/extensions/contexts/cm-forms/field-core-group-multiselect.spec.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-multiselect.spec.js
@@ -1,0 +1,90 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+import GroupMultiselect from './field-core-group-multiselect'
+import Category from '../../../data-dictionary/global-categories/category'
+import Role from '../../../data-dictionary/global-roles/role'
+import Group from '../../../data-dictionary/global-groups/group'
+
+describe('GroupMultiselect', () => {
+  let field, data, ctx, parent, getFn, listFn
+  beforeEach(() => {
+    getFn = jest.fn()
+    listFn = jest.fn()
+    parent = { deflate: jest.fn(), getValue: jest.fn().mockReturnValue({}) }
+    ctx = { apis: { categories: { get: getFn }, groups: { list: listFn } } }
+    data = { type: 'foo', formKey: 'bar', label: 'baz', categoryId: 'cat1' }
+    field = new GroupMultiselect(parent, '*', data, ctx)
+  })
+
+  it('inflates', async () => {
+    const val = await GroupMultiselect.inflate(null, { data: 'Stuff' })
+    expect(val).toBe('Stuff')
+  })
+
+  it('deflates with no parent', () => {
+    const valueList = []
+    field = new GroupMultiselect(undefined, '*', data, ctx)
+    field.deflate(valueList)
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: GroupMultiselect.type,
+      name: data.label,
+      data,
+      formKey: data.formKey,
+      requiresParent: false
+    })
+  })
+
+  it('deflates with parent', () => {
+    const valueList = field.deflate()
+    expect(parent.deflate).toHaveBeenCalled()
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: GroupMultiselect.type,
+      name: data.label,
+      data,
+      formKey: data.formKey,
+      requiresParent: false
+    })
+  })
+
+  describe('getChildren', () => {
+    it('finds role children', async () => {
+      getFn.mockReturnValue({ roleSchemas: ['role1'] })
+      listFn.mockReturnValue([])
+      const children = await field.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(Role.type)
+    })
+
+    it('finds category children', async () => {
+      getFn.mockReturnValue({ parentId: 'p123', roleSchemas: [] })
+      listFn.mockReturnValue([])
+      const children = await field.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(Category.type)
+    })
+
+    it('finds group children', async () => {
+      getFn.mockReturnValue({ roleSchemas: [] })
+      listFn.mockReturnValue(['groupA'])
+      const children = await field.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(Group.type)
+    })
+  })
+
+  describe('getValue', () => {
+    it('returns formKey', () => {
+      const valueMap = {}
+      field.getValue(valueMap)
+      expect(valueMap.formKey).toBe('bar')
+    })
+  })
+})

--- a/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
@@ -8,6 +8,7 @@
 import CMField from './field'
 import Category from '../../../data-dictionary/global-categories/category'
 import Role from '../../../data-dictionary/global-roles/role'
+import Group from '../../../data-dictionary/global-groups/group'
 import { GROUP, TEXT } from '../../../data-dictionary/return-types'
 
 export default class FieldCoreGroupTypeahead extends CMField {
@@ -24,12 +25,18 @@ export default class FieldCoreGroupTypeahead extends CMField {
     const { categoryId } = this.data
     const category = await this.ctx.apis.categories.get(categoryId)
     const { parentId, roleSchemas } = category
-    const children = roleSchemas.map(
+    let children = roleSchemas.map(
       role => new Role(this, this.returnTypes, role, this.ctx)
     )
     if (parentId) {
       const pData = await this.ctx.apis.categories.get(parentId)
       children.unshift(new Category(this, this.returnTypes, pData, this.ctx))
+    }
+    if (this.ctx) {
+      const groups = await this.ctx.apis.groups.list(filter)
+      children = children.concat(groups.map(
+        group => new Group(this, this.returnTypes, group, this.ctx)
+      ))
     }
     return children
   }

--- a/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
@@ -32,12 +32,10 @@ export default class FieldCoreGroupTypeahead extends CMField {
       const pData = await this.ctx.apis.categories.get(parentId)
       children.unshift(new Category(this, this.returnTypes, pData, this.ctx))
     }
-    if (this.ctx) {
-      const groups = await this.ctx.apis.groups.list(filter)
-      children = children.concat(groups.map(
-        group => new Group(this, this.returnTypes, group, this.ctx)
-      ))
-    }
+    const groups = await this.ctx.apis.groups.list(filter)
+    children = children.concat(groups.map(
+      group => new Group(this, this.returnTypes, group, this.ctx)
+    ))
     return children
   }
 

--- a/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
@@ -57,13 +57,7 @@ export default class FieldCoreGroupTypeahead extends CMField {
   }
 
   async getValue (valueMap = {}) {
-    const { data, parent } = this
-    if (parent) await parent.getValue(valueMap)
-    if (!valueMap.formfill || !valueMap.formfill.document) return
-    const { document } = valueMap.formfill
-    const groupId = document.data[data.formKey].id
-    const group = await this.ctx.apis.groups.get(groupId)
-    valueMap.field = { value: group }
-    return group
+    super.getValue(valueMap)
+    valueMap.formKey = this.data.formKey
   }
 }

--- a/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
@@ -1,0 +1,62 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import CMField from './field'
+import Category from '../../../data-dictionary/global-categories/category'
+import Role from '../../../data-dictionary/global-roles/role'
+import { GROUP, TEXT } from '../../../data-dictionary/return-types'
+
+export default class FieldCoreGroupTypeahead extends CMField {
+  static fieldType = 'GroupsTypeahead'
+  static type = 'cm-field-core-group-typeahead'
+  static returnTypes = [GROUP, TEXT]
+  static matchTypes = [GROUP, TEXT]
+
+  static async inflate (ctx, deflated, parent) {
+    return deflated.data
+  }
+
+  getChildren = async filter => {
+    const { categoryId } = this.data
+    const category = await this.ctx.apis.categories.get(categoryId)
+    const { parentId, roleSchemas } = category
+    const children = roleSchemas.map(
+      role => new Role(this, this.returnTypes, role, this.ctx)
+    )
+    if (parentId) {
+      const pData = await this.ctx.apis.categories.get(parentId)
+      children.unshift(new Category(this, this.returnTypes, pData, this.ctx))
+    }
+    return children
+  }
+
+  isLeaf = () => false
+
+  deflate (valueList = []) {
+    const { parent, type, name, data } = this
+    if (parent) parent.deflate(valueList)
+    valueList.push({
+      type,
+      name,
+      data,
+      formKey: data.formKey,
+      requiresParent: false
+    })
+    return valueList
+  }
+
+  async getValue (valueMap = {}) {
+    const { data, parent } = this
+    if (parent) await parent.getValue(valueMap)
+    if (!valueMap.formfill || !valueMap.formfill.document) return
+    const { document } = valueMap.formfill
+    const groupId = document.data[data.formKey].id
+    const group = await this.ctx.apis.groups.get(groupId)
+    valueMap.field = { value: group }
+    return group
+  }
+}

--- a/src/extensions/contexts/cm-forms/field-core-group-typeahead.spec.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-typeahead.spec.js
@@ -1,0 +1,91 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+import GroupTypeahead from './field-core-group-typeahead'
+import Category from '../../../data-dictionary/global-categories/category'
+import Role from '../../../data-dictionary/global-roles/role'
+import Group from '../../../data-dictionary/global-groups/group'
+
+describe('GroupTypeahead', () => {
+  let field, data, ctx, parent, getFn, listFn
+  beforeEach(() => {
+    getFn = jest.fn()
+    listFn = jest.fn()
+    parent = { deflate: jest.fn(), getValue: jest.fn().mockReturnValue({}) }
+    ctx = { apis: { categories: { get: getFn }, groups: { list: listFn }}}
+    data = { type: 'foo', formKey: 'bar', label: 'baz', categoryId: 'cat1' }
+    field = new GroupTypeahead(parent, '*', data, ctx)
+  })
+
+  it('inflates', async () => {
+    const val = await GroupTypeahead.inflate(null, { data: 'Stuff' })
+    expect(val).toBe('Stuff')
+  })
+
+  it('deflates with no parent', () => {
+    const valueList = []
+    field = new GroupTypeahead(undefined, '*', data, ctx)
+    field.deflate(valueList)
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: GroupTypeahead.type,
+      name: data.label,
+      data,
+      formKey: data.formKey,
+      requiresParent: false
+    })
+  })
+
+  it('deflates with parent', () => {
+    const valueList = field.deflate()
+    expect(parent.deflate).toHaveBeenCalled()
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: GroupTypeahead.type,
+      name: data.label,
+      data,
+      formKey: data.formKey,
+      requiresParent: false
+    })
+  })
+
+  describe('getChildren', () => {
+    it('finds role children', async () => {
+      getFn.mockReturnValue({ roleSchemas: ['role1']})
+      listFn.mockReturnValue([])
+      const children = await field.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(Role.type)
+    })
+
+    it('finds category children', async () => {
+      getFn.mockReturnValue({ parentId: 'p123', roleSchemas: []})
+      listFn.mockReturnValue([])
+      const children = await field.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(Category.type)
+    })
+
+    it('finds group children', async () => {
+      getFn.mockReturnValue({ roleSchemas: []})
+      listFn.mockReturnValue(['groupA'])
+      const children = await field.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(Group.type)
+    })
+  })
+
+  describe('getValue', () => {
+    it('returns formKey', () => {
+      const valueMap = {}
+      field.getValue(valueMap)
+      expect(valueMap.formKey).toBe('bar')
+    })
+  })
+})
+

--- a/src/extensions/contexts/cm-forms/field-radio-button.js
+++ b/src/extensions/contexts/cm-forms/field-radio-button.js
@@ -1,0 +1,20 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import CMField from './field'
+import { NUMBER, TEXT } from '../../../data-dictionary/return-types'
+
+export default class FieldRadioButton extends CMField {
+  static fieldType = 'Radios'
+  static type = 'cm-field-radio-button'
+  static returnTypes = [NUMBER, TEXT]
+  static matchTypes = [NUMBER, TEXT]
+
+  getChildren = async filter => []
+
+  isLeaf = () => true
+}

--- a/src/extensions/contexts/cm-forms/field-radio-button.js
+++ b/src/extensions/contexts/cm-forms/field-radio-button.js
@@ -5,7 +5,9 @@
  * You should have received a copy of the Kuali, Inc. Pre-Release License
  * Agreement with this file. If not, please write to license@kuali.co.
  */
+import { get, map } from 'lodash'
 import CMField from './field'
+import RadioOption from './radio-option'
 import { NUMBER, TEXT } from '../../../data-dictionary/return-types'
 
 export default class FieldRadioButton extends CMField {
@@ -14,7 +16,22 @@ export default class FieldRadioButton extends CMField {
   static returnTypes = [NUMBER, TEXT]
   static matchTypes = [NUMBER, TEXT]
 
-  getChildren = async filter => []
+  getChildren = async () => {
+    const { data, parent } = this
+    const schema = get(parent, 'data.schema')
+    const formKey = get(data, 'formKey')
+    if (!data || !schema || !formKey) return []
+    const options = get(schema[formKey], 'options', [])
+    const children = map(options, (optionData) => {
+      return new RadioOption(
+        this,
+        this.returnTypes,
+        optionData,
+        this.ctx
+      )
+    })
+    return children
+  }
 
-  isLeaf = () => true
+  isLeaf = () => false
 }

--- a/src/extensions/contexts/cm-forms/field-radio-button.spec.js
+++ b/src/extensions/contexts/cm-forms/field-radio-button.spec.js
@@ -1,0 +1,46 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+import RadioButton from './field-radio-button'
+import RadioOption from './radio-option'
+
+describe('RadioButton', () => {
+  let parent, ctx, data, field
+  beforeEach(() => {
+    parent = { data: { schema: { bar: { options: [{ key: 'opt1' }] } } } }
+    ctx = 'some ctx object'
+    data = { type: 'foo', formKey: 'bar', label: 'baz', categoryId: 'cat1' }
+    field = new RadioButton(parent, '*', data, ctx)
+  })
+
+  describe('getChildren', () => {
+    it('returns empty array if data is missing', async () => {
+      field.data = undefined
+      const children = await field.getChildren()
+      expect(children).toEqual([])
+    })
+
+    it('returns empty array if schema is missing', async () => {
+      field.parent.data.schema = undefined
+      const children = await field.getChildren()
+      expect(children).toEqual([])
+    })
+
+    it('returns empty array if formKey is missing', async () => {
+      field.data.formKey = undefined
+      const children = await field.getChildren()
+      expect(children).toEqual([])
+    })
+
+    it('returns RadioOption children', async () => {
+      const children = await field.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(RadioOption.type)
+    })
+  })
+})

--- a/src/extensions/contexts/cm-forms/field-text-area.js
+++ b/src/extensions/contexts/cm-forms/field-text-area.js
@@ -13,8 +13,4 @@ export default class FieldTextArea extends CMField {
   static type = 'cm-field-text-area'
   static returnTypes = [NUMBER, TEXT]
   static matchTypes = [NUMBER, TEXT]
-
-  getChildren = async filter => []
-
-  isLeaf = () => true
 }

--- a/src/extensions/contexts/cm-forms/field-text-area.js
+++ b/src/extensions/contexts/cm-forms/field-text-area.js
@@ -1,0 +1,20 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import CMField from './field'
+import { NUMBER, TEXT } from '../../../data-dictionary/return-types'
+
+export default class FieldTextArea extends CMField {
+  static fieldType = 'Textarea'
+  static type = 'cm-field-text-area'
+  static returnTypes = [NUMBER, TEXT]
+  static matchTypes = [NUMBER, TEXT]
+
+  getChildren = async filter => []
+
+  isLeaf = () => true
+}

--- a/src/extensions/contexts/cm-forms/field-text-input.js
+++ b/src/extensions/contexts/cm-forms/field-text-input.js
@@ -1,0 +1,16 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import CMField from './field'
+import { NUMBER, TEXT } from '../../../data-dictionary/return-types'
+
+export default class CMFieldTextInput extends CMField {
+  static fieldType = 'Text'
+  static type = 'cm-field-text-input'
+  static returnTypes = [NUMBER, TEXT]
+  static matchTypes = [NUMBER, TEXT]
+}

--- a/src/extensions/contexts/cm-forms/field.js
+++ b/src/extensions/contexts/cm-forms/field.js
@@ -42,11 +42,19 @@ export default class CMField extends Context {
   }
 
   /**
-   * Expect the parent form to have provided a document containing values
+   * Expect the parent form to have provided an item containing form values
    * @param {Object} valueMap a map of parent's output
    */
   async getValue (valueMap = {}) {
-    throw new Error('Unimplemented')
+    const { data, parent } = this
+    if (parent) {
+      const parentData = await parent.getValue(valueMap)
+      if (parentData.item) {
+        const value = parentData.item[data.formKey]
+        valueMap.field = { value }
+        return value
+      }
+    }
   }
 
   // --- Utility Functions ---

--- a/src/extensions/contexts/cm-forms/field.js
+++ b/src/extensions/contexts/cm-forms/field.js
@@ -1,0 +1,60 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import { isEqual } from 'lodash'
+import Context from '../../../data-dictionary/context'
+
+export default class CMField extends Context {
+  static fieldType = 'Unknown'
+  static type = 'cmfield'
+  static displayName = 'CM Field'
+  static returnTypes = '*'
+
+  static async inflate (ctx, deflated, parent) {
+    return {...deflated, schema: parent.data.schema[deflated.formKey]}
+  }
+
+  constructor (parent, returnTypes, data, ctx) {
+    super(parent, returnTypes, data, ctx)
+    this.validate(data)
+    this.name = data.label
+  }
+
+  getChildren = async filter => []
+
+  isLeaf = () => true
+
+  isEqual = context => {
+    if (!context || !context.data) return false
+    return isEqual(this.data, context.data)
+  }
+
+  deflate (valueList = []) {
+    const { parent, type, name, data } = this
+    if (parent) parent.deflate(valueList)
+    valueList.push({ type, name, formKey: data.formKey, label: data.label, requiresParent: true })
+    return valueList
+  }
+
+  /**
+   * Expect the parent form to have provided a document containing values
+   * @param {Object} valueMap a map of parent's output
+   */
+  async getValue (valueMap = {}) {
+    throw new Error('Unimplemented')
+  }
+
+  // --- Utility Functions ---
+
+  validate (data) {
+    if (!data || !data.type || !data.formKey || !data.label) {
+      throw new Error(
+        'Cannot create a CM Field Context without propperly formatted form data'
+      )
+    }
+  }
+}

--- a/src/extensions/contexts/cm-forms/field.spec.js
+++ b/src/extensions/contexts/cm-forms/field.spec.js
@@ -1,0 +1,114 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+import CMField from './field'
+
+describe('Field', () => {
+  let parent, ctx, data, field
+  beforeEach(() => {
+    parent = {
+      deflate: jest.fn(),
+      getValue: jest.fn(),
+      data: { schema: { bar: { options: [{ key: 'opt1' }] } } }
+    }
+    ctx = 'some ctx object'
+    data = { type: 'foo', formKey: 'bar', label: 'baz', categoryId: 'cat1' }
+    field = new CMField(parent, '*', data, ctx)
+  })
+
+  it('inflates', async () => {
+    const val = await CMField.inflate(null, data, parent)
+    expect(val).toEqual({ ...data, schema: parent.data.schema.bar })
+  })
+
+  describe('isEqual', () => {
+    it('returns false if context is falsy', () => {
+      expect(field.isEqual()).toBe(false)
+    })
+
+    it('returns false if context.data is falsy', () => {
+      expect(field.isEqual({})).toBe(false)
+    })
+
+    it('returns true if context.data is equal to this.data', () => {
+      expect(field.isEqual({ data })).toBe(true)
+    })
+  })
+
+  it('deflates with no parent', () => {
+    const valueList = []
+    field = new CMField(undefined, '*', data, ctx)
+    field.deflate(valueList)
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: CMField.type,
+      name: data.label,
+      label: data.label,
+      formKey: data.formKey,
+      requiresParent: true
+    })
+  })
+
+  it('deflates with parent', () => {
+    const valueList = field.deflate()
+    expect(parent.deflate).toHaveBeenCalled()
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: CMField.type,
+      name: data.label,
+      label: data.label,
+      formKey: data.formKey,
+      requiresParent: true
+    })
+  })
+
+  describe('getValue', () => {
+    it('returns nothing if parent is not set', async () => {
+      field = new CMField(undefined, '*', data, ctx)
+      const value = await field.getValue()
+      expect(value).toBeUndefined()
+    })
+
+    it('returns nothing if parent value has no item', async () => {
+      parent.getValue.mockReturnValue({})
+      const value = await field.getValue()
+      expect(value).toBeUndefined()
+    })
+
+    it('gets value from parent item', async () => {
+      parent.getValue.mockReturnValue({ item: { bar: 'VALUE' } })
+      const valueMap = {}
+      const value = await field.getValue(valueMap)
+      expect(value).toBe('VALUE')
+      expect(valueMap).toEqual({ field: { value } })
+    })
+  })
+
+  describe('validate', () => {
+    it('errors if data is falsy', () => {
+      expect(() => {
+        field.validate()
+      }).toThrow()
+    })
+    it('errors if data.type is falsy', () => {
+      expect(() => {
+        field.validate({})
+      }).toThrow()
+    })
+    it('errors if data.formKey is falsy', () => {
+      expect(() => {
+        field.validate({ type: 'blah' })
+      }).toThrow()
+    })
+    it('errors if data.label is falsy', () => {
+      expect(() => {
+        field.validate({ type: 'blah', formKey: 'key' })
+      }).toThrow()
+    })
+  })
+})

--- a/src/extensions/contexts/cm-forms/fields-common.spec.js
+++ b/src/extensions/contexts/cm-forms/fields-common.spec.js
@@ -1,0 +1,57 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+import Checkbox from './field-checkbox'
+import GroupMultiselect from './field-core-group-multiselect'
+import GroupTypeahead from './field-core-group-typeahead'
+import RadioButton from './field-radio-button'
+import TextArea from './field-text-area'
+import TextInput from './field-text-input'
+
+import { BOOLEAN, GROUP, NUMBER, TEXT } from '../../../data-dictionary/return-types'
+
+testCMField(Checkbox, [BOOLEAN], [BOOLEAN], true)
+testCMField(GroupMultiselect, [GROUP, TEXT], [GROUP, TEXT])
+testCMField(GroupTypeahead, [GROUP, TEXT], [GROUP, TEXT])
+testCMField(RadioButton, [NUMBER, TEXT], [NUMBER, TEXT])
+testCMField(TextArea, [NUMBER, TEXT], [NUMBER, TEXT], true)
+testCMField(TextInput, [NUMBER, TEXT], [NUMBER, TEXT], true)
+
+export function mockFieldData () {
+  return { type: 'foo', formKey: 'bar', label: 'baz' }
+}
+
+function testCMField (
+  Field,
+  returnTypes,
+  matchTypes,
+  isLeaf = false
+) {
+  describe(Field.displayName, () => {
+    let field, data
+    beforeEach(() => {
+      data = mockFieldData()
+      field = new Field(null, null, data)
+    })
+
+    it('should have the the proper return and match types', () => {
+      expect(Field.returnTypes).toMatchObject(returnTypes)
+      expect(Field.matchTypes).toMatchObject(matchTypes)
+    })
+
+    it('returns expected value for isLeaf', () => {
+      if (isLeaf) {
+        expect(field.isLeaf()).toBeTruthy()
+      } else {
+        expect(field.isLeaf()).toBeFalsy()
+      }
+    })
+  })
+}
+
+

--- a/src/extensions/contexts/cm-forms/form.js
+++ b/src/extensions/contexts/cm-forms/form.js
@@ -12,12 +12,14 @@ import { ALL } from '../../../data-dictionary/return-types'
 import { CMFORM } from '../../return-types'
 import CMFieldTextInput from './field-text-input'
 import CMFieldCoreGroupTypeahead from './field-core-group-typeahead'
+import CMFieldCoreGroupMultiselect from './field-core-group-multiselect'
 import CMFieldRadioButton from './field-radio-button'
 import CMFieldTextArea from './field-text-area'
 
 const fieldList = {
   CMFieldTextInput,
   CMFieldCoreGroupTypeahead,
+  CMFieldCoreGroupMultiselect,
   CMFieldRadioButton,
   CMFieldTextArea
 }

--- a/src/extensions/contexts/cm-forms/form.js
+++ b/src/extensions/contexts/cm-forms/form.js
@@ -12,10 +12,14 @@ import { ALL } from '../../../data-dictionary/return-types'
 import { CMFORM } from '../../return-types'
 import CMFieldTextInput from './field-text-input'
 import CMFieldCoreGroupTypeahead from './field-core-group-typeahead'
+import CMFieldRadioButton from './field-radio-button'
+import CMFieldTextArea from './field-text-area'
 
 const fieldList = {
   CMFieldTextInput,
-  CMFieldCoreGroupTypeahead
+  CMFieldCoreGroupTypeahead,
+  CMFieldRadioButton,
+  CMFieldTextArea
 }
 const fieldMap = keyBy(fieldList, 'fieldType')
 

--- a/src/extensions/contexts/cm-forms/form.js
+++ b/src/extensions/contexts/cm-forms/form.js
@@ -1,0 +1,107 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import { compact, isArray, keyBy, map } from 'lodash'
+
+import Context from '../../../data-dictionary/context'
+import { ALL } from '../../../data-dictionary/return-types'
+import { CMFORM } from '../../return-types'
+import CMFieldTextInput from './field-text-input'
+import CMFieldCoreGroupTypeahead from './field-core-group-typeahead'
+
+const fieldList = {
+  CMFieldTextInput,
+  CMFieldCoreGroupTypeahead
+}
+const fieldMap = keyBy(fieldList, 'fieldType')
+
+/**
+ * Creates a Form Context
+ *
+ * @param {Object} parent The parent Context
+ * @param {Array|String} returnTypes The array of contexts or '*' for all
+ * @param {Object} data The parent Context
+ */
+export default class Form extends Context {
+  static global = false
+  static type = 'cmformfill'
+  static matchTypes = CMFORM
+
+  static async inflate (ctx, deflated) {
+    const schema = await ctx.apis.cm.schema(deflated._id)
+    return Object.assign({}, deflated, { schema })
+  }
+
+  constructor (parent, returnTypes, data, ctx) {
+    super(parent, returnTypes, data, ctx)
+    // this.validate(data)
+    this.name = data.lbl
+  }
+
+  async getChildren (noop) {
+    if (!this.data || !this.data._id) return []
+    const schema =
+      this.data.schema || (await this.ctx.apis.cm.schema(this.data._id))
+    const myReturnTypes = isArray(this.returnTypes)
+      ? this.returnTypes
+      : [this.returnTypes]
+    const children = map(schema, (field, formKey) => {
+      const FieldContext = fieldMap[field.type]
+      if (
+        FieldContext &&
+        (myReturnTypes.includes(ALL) ||
+        FieldContext.returnTypes === ALL ||
+        FieldContext.returnTypes.some(type =>
+          this.returnTypes.includes(type)
+        ))
+      ) {
+        return new FieldContext(
+          this,
+          this.returnTypes,
+          { formKey, ...field },
+          this.ctx
+        )
+      }
+    })
+    return compact(children)
+  }
+
+  matches (match) {
+    if (!this.match || !match) return false
+    if (match === CMFORM) return true
+    const thisMatch = isArray(this.match) ? this.match : [this.match]
+    const thatMatch = isArray(match) ? match : [match]
+    return thisMatch.some(tm => thatMatch.includes(tm)) || false
+  }
+
+  isLeaf () {
+    return false
+  }
+
+  deflate (valueList = []) {
+    const { parent, type, name, data } = this
+    if (parent) parent.deflate(valueList)
+    valueList.push({
+      type,
+      name,
+      _id: data._id,
+      lbl: data.lbl,
+      requiresParent: false
+    })
+    return valueList
+  }
+
+  // --- Utility Functions ---
+
+  validate (data) {
+    if (!data || !data._id) {
+      throw new Error(
+        'Cannot create a Form Context without propperly formatted form data'
+      )
+    }
+  }
+}

--- a/src/extensions/contexts/cm-forms/form.js
+++ b/src/extensions/contexts/cm-forms/form.js
@@ -46,7 +46,7 @@ export default class Form extends Context {
 
   constructor (parent, returnTypes, data, ctx) {
     super(parent, returnTypes, data, ctx)
-    // this.validate(data)
+    this.validate(data)
     this.name = data.lbl
   }
 

--- a/src/extensions/contexts/cm-forms/form.js
+++ b/src/extensions/contexts/cm-forms/form.js
@@ -14,6 +14,7 @@ import CMFieldTextInput from './field-text-input'
 import CMFieldCoreGroupTypeahead from './field-core-group-typeahead'
 import CMFieldCoreGroupMultiselect from './field-core-group-multiselect'
 import CMFieldRadioButton from './field-radio-button'
+import CMFieldCheckbox from './field-checkbox'
 import CMFieldTextArea from './field-text-area'
 
 const fieldList = {
@@ -21,6 +22,7 @@ const fieldList = {
   CMFieldCoreGroupTypeahead,
   CMFieldCoreGroupMultiselect,
   CMFieldRadioButton,
+  CMFieldCheckbox,
   CMFieldTextArea
 }
 const fieldMap = keyBy(fieldList, 'fieldType')

--- a/src/extensions/contexts/cm-forms/form.spec.js
+++ b/src/extensions/contexts/cm-forms/form.spec.js
@@ -1,0 +1,163 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+import Form from './form'
+import CMFieldRadioButton from './field-radio-button'
+import { CMFORM } from '../../return-types'
+
+describe('Form', () => {
+  let form, data, ctx, parent, schemaFn, listFn
+  beforeEach(() => {
+    schemaFn = jest.fn()
+    listFn = jest.fn()
+    parent = { deflate: jest.fn() }
+    ctx = { apis: { cm: { schema: schemaFn } } }
+    data = {
+      _id: 'courses',
+      type: 'foo',
+      formKey: 'bar',
+      lbl: 'baz',
+      categoryId: 'cat1'
+    }
+    form = new Form(parent, ['*'], data, ctx)
+  })
+
+  it('inflates', async () => {
+    const mockSchema = { key: 'value' }
+    schemaFn.mockReturnValue(mockSchema)
+    const val = await Form.inflate(ctx, { _id: '123' })
+    expect(schemaFn).toHaveBeenCalledWith('123')
+    expect(val).toEqual({ _id: '123', schema: mockSchema })
+  })
+
+  it('deflates with no parent', () => {
+    const valueList = []
+    form = new Form(undefined, '*', data, ctx)
+    form.deflate(valueList)
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: Form.type,
+      name: data.lbl,
+      _id: data._id,
+      lbl: data.lbl,
+      requiresParent: false
+    })
+  })
+
+  it('deflates with parent', () => {
+    const valueList = form.deflate()
+    expect(parent.deflate).toHaveBeenCalled()
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: Form.type,
+      name: data.lbl,
+      _id: data._id,
+      lbl: data.lbl,
+      requiresParent: false
+    })
+  })
+
+  describe('getChildren', () => {
+    it('returns empty array if data is falsy', async () => {
+      form.data = undefined
+      const children = await form.getChildren()
+      expect(children).toEqual([])
+    })
+    it('returns empty array if data._id is falsy', async () => {
+      form.data = {}
+      const children = await form.getChildren()
+      expect(children).toEqual([])
+    })
+    it('uses cached schema if it exists', async () => {
+      form.data.schema = {
+        foo: { type: 'Radios', formKey: 'foo', label: 'Foo' }
+      }
+      const children = await form.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(CMFieldRadioButton.type)
+    })
+    it('uses schema api if no cached schema exists', async () => {
+      form.data.schema = undefined
+      schemaFn.mockReturnValue({
+        foo: { type: 'Radios', formKey: 'foo', label: 'Foo' }
+      })
+      const children = await form.getChildren()
+      expect(schemaFn).toHaveBeenCalled()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(CMFieldRadioButton.type)
+    })
+    it('handles returnTypes that is not an array', async () => {
+      form = new Form(parent, '*', data, ctx)
+      form.data.schema = {
+        foo: { type: 'Radios', formKey: 'foo', label: 'Foo' }
+      }
+      const children = await form.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(CMFieldRadioButton.type)
+    })
+    it('ignores schema items that do not match a supported field type', async () => {
+      form.data.schema = {
+        foo: { type: 'Radios', formKey: 'foo', label: 'Foo' },
+        mystery: { type: 'Mystery' }
+      }
+      const children = await form.getChildren()
+      expect(children.length).toBe(1)
+      expect(children[0].type).toBe(CMFieldRadioButton.type)
+    })
+    it('ignores schema items that do not match returnTypes', async () => {
+      form = new Form(parent, 'MYSTERY', data, ctx)
+      form.data.schema = {
+        foo: { type: 'Radios', formKey: 'foo', label: 'Foo' }
+      }
+      const children = await form.getChildren()
+      expect(children.length).toBe(0)
+    })
+  })
+
+  describe('matches', () => {
+    it('returns false if passed match is falsy', () => {
+      expect(form.matches()).toBe(false)
+    })
+    it('returns false if this.match is falsy', () => {
+      form.match = false
+      expect(form.matches(false)).toBe(false)
+    })
+    it('returns true if match is CMFORM', () => {
+      form.match = 'anything'
+      expect(form.matches(CMFORM)).toBe(true)
+    })
+    it('matches strings', () => {
+      form.match = 'A'
+      expect(form.matches('A')).toBe(true)
+    })
+    it('matches ARRAYS', () => {
+      form.match = ['A','B']
+      expect(form.matches(['B','C'])).toBe(true)
+    })
+    it('return false when things do not match', () => {
+      form.match = 'A'
+      expect(form.matches('B')).toBe(false)
+    })
+  })
+
+  it('is not a leaf', () => {
+    expect(form.isLeaf()).toBe(false)
+  })
+
+  it('fails to construct if data is missing', () => {
+    expect(() => {
+      form = new Form(parent, '*', undefined, ctx)
+    }).toThrow()
+  })
+
+  it('fails to construct if data._id is missing', () => {
+    expect(() => {
+      form = new Form(parent, '*', {}, ctx)
+    }).toThrow()
+  })
+})

--- a/src/extensions/contexts/cm-forms/index.js
+++ b/src/extensions/contexts/cm-forms/index.js
@@ -1,0 +1,75 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import { get } from 'lodash'
+
+import Context from '../../../data-dictionary/context'
+import Form from './form'
+import { CMFORM } from '../../return-types'
+
+export default class CMForms extends Context {
+  static global = false
+  static type = 'cm-forms'
+  static displayName = 'CM Forms'
+  static returnTypes = [CMFORM]
+
+  static async inflate (ctx, deflated) {
+    return deflated
+  }
+
+  async getChildren (filter) {
+    if (!this.ctx) throw new Error('no ctx')
+    const institution = await this.ctx.apis.cm.institution()
+    const settings = await this.ctx.apis.cm.settings()
+    const forms = CMForms.extractFormOptionsFromSettings(institution, settings)
+    const formCtxs = forms.map(
+      form => new Form(this, this.returnTypes, form, this.ctx)
+    )
+    return formCtxs
+  }
+
+  deflate (valueList = []) {
+    const { parent, type, name } = this
+    if (parent) parent.deflate(valueList)
+    valueList.push({ type, name, requiresParent: false })
+    return valueList
+  }
+
+  static extractFormOptionsFromSettings (institution, settings) {
+    const formOptions = [
+      {
+        _id: 'courses',
+        lbl: get(settings, 'uiTextReplacements.course') || 'Courses'
+      },
+      {
+        _id: 'programs',
+        lbl: get(settings, 'uiTextReplacements.program') || 'Programs'
+      }
+    ]
+    if (get(institution, 'flags.experienceItem')) {
+      formOptions.push({
+        _id: 'experiences',
+        lbl: get(settings, 'uiTextReplacements.experience') || 'Experiences '
+      })
+    }
+    if (get(institution, 'flags.specializationItem')) {
+      formOptions.push({
+        _id: 'specializations',
+        lbl:
+        get(settings, 'uiTextReplacements.specialization') ||
+        'Specializations'
+      })
+    }
+    if (get(institution, 'flags.policies')) {
+      formOptions.push({
+        _id: 'policies',
+        lbl: get(settings, 'uiTextReplacements.policie') || 'Policies'
+      })
+    }
+    return formOptions
+  }
+}

--- a/src/extensions/contexts/cm-forms/index.js
+++ b/src/extensions/contexts/cm-forms/index.js
@@ -22,7 +22,7 @@ export default class CMForms extends Context {
   }
 
   async getChildren (filter) {
-    if (!this.ctx) throw new Error('no ctx')
+    if (!this.ctx) return []
     const institution = await this.ctx.apis.cm.institution()
     const settings = await this.ctx.apis.cm.settings()
     const forms = CMForms.extractFormOptionsFromSettings(institution, settings)
@@ -53,7 +53,7 @@ export default class CMForms extends Context {
     if (get(institution, 'flags.experienceItem')) {
       formOptions.push({
         _id: 'experiences',
-        lbl: get(settings, 'uiTextReplacements.experience') || 'Experiences '
+        lbl: get(settings, 'uiTextReplacements.experience') || 'Experiences'
       })
     }
     if (get(institution, 'flags.specializationItem')) {

--- a/src/extensions/contexts/cm-forms/index.spec.js
+++ b/src/extensions/contexts/cm-forms/index.spec.js
@@ -1,0 +1,118 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+import CMForms from './index'
+
+describe('CMForms', () => {
+  let form, data, ctx, parent, institutionFn, settingsFn
+  beforeEach(() => {
+    institutionFn = jest.fn()
+    settingsFn = jest.fn()
+    parent = { deflate: jest.fn() }
+    ctx = { apis: { cm: { institution: institutionFn, settings: settingsFn } } }
+    data = {}
+    form = new CMForms(parent, ['*'], data, ctx)
+  })
+
+  it('inflates', async () => {
+    const val = await CMForms.inflate(ctx, 'Some object')
+    expect(val).toEqual('Some object')
+  })
+
+  it('deflates with no parent', () => {
+    const valueList = []
+    form = new CMForms(undefined, '*', data, ctx)
+    form.deflate(valueList)
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: CMForms.type,
+      name: CMForms.displayName,
+      requiresParent: false
+    })
+  })
+
+  it('deflates with parent', () => {
+    const valueList = form.deflate()
+    expect(parent.deflate).toHaveBeenCalled()
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: CMForms.type,
+      name: CMForms.displayName,
+      requiresParent: false
+    })
+  })
+
+  describe('getChildren', () => {
+    it('returns empty array if there is no context', async () => {
+      form = new CMForms(undefined, '*', data, undefined)
+      const children = await form.getChildren()
+      expect(children).toEqual([])
+    })
+    it('returns course and program children by default', async () => {
+      settingsFn.mockReturnValue({})
+      institutionFn.mockReturnValue({})
+      const children = await form.getChildren()
+      expect(children.length).toBe(2)
+      expect(children[0].name).toBe('Courses')
+      expect(children[1].name).toBe('Programs')
+    })
+    it('returns course and program children by default', async () => {
+      settingsFn.mockReturnValue({})
+      institutionFn.mockReturnValue({})
+      const children = await form.getChildren()
+      expect(children.length).toBe(2)
+      expect(children[0].name).toBe('Courses')
+      expect(children[1].name).toBe('Programs')
+    })
+    it('includes additional form types when they are turned on', async () => {
+      const mockInstitution = {
+        flags: {
+          experienceItem: true,
+          specializationItem: true,
+          policies: true
+        }
+      }
+      settingsFn.mockReturnValue({})
+      institutionFn.mockReturnValue(mockInstitution)
+      const children = await form.getChildren()
+      expect(children.length).toBe(5)
+      expect(children[0].name).toBe('Courses')
+      expect(children[1].name).toBe('Programs')
+      expect(children[2].name).toBe('Experiences')
+      expect(children[3].name).toBe('Specializations')
+      expect(children[4].name).toBe('Policies')
+    })
+    it('uses ui text replacements when they are set', async () => {
+      const mockSettings = {
+        uiTextReplacements: {
+          course: 'A',
+          program: 'B',
+          experience: 'C',
+          specialization: 'D',
+          policie: 'E'
+        }
+      }
+      const mockInstitution = {
+        flags: {
+          experienceItem: true,
+          specializationItem: true,
+          policies: true
+        }
+      }
+      settingsFn.mockReturnValue(mockSettings)
+      institutionFn.mockReturnValue(mockInstitution)
+      const children = await form.getChildren()
+      expect(children.length).toBe(5)
+      expect(children[0].name).toBe('A')
+      expect(children[1].name).toBe('B')
+      expect(children[2].name).toBe('C')
+      expect(children[3].name).toBe('D')
+      expect(children[4].name).toBe('E')
+    })
+  })
+})

--- a/src/extensions/contexts/cm-forms/radio-option.js
+++ b/src/extensions/contexts/cm-forms/radio-option.js
@@ -55,9 +55,9 @@ export default class RadioOption extends Context {
   // --- Utility Functions ---
 
   validate (data) {
-    if (!data || !data.key || !data.text) {
+    if (!data || !data.key) {
       throw new Error(
-        `Invalid RadioOption value: ${data}`
+        `Invalid RadioOption value: ${JSON.stringify(data)}`
       )
     }
   }

--- a/src/extensions/contexts/cm-forms/radio-option.js
+++ b/src/extensions/contexts/cm-forms/radio-option.js
@@ -7,22 +7,23 @@
  */
 import { isEqual } from 'lodash'
 import Context from '../../../data-dictionary/context'
+import { NUMBER, TEXT } from '../../../data-dictionary/return-types'
 
-export default class CMField extends Context {
-  static fieldType = 'Unknown'
-  static type = 'cmfield'
-  static displayName = 'CM Field'
-  static returnTypes = '*'
+export default class RadioOption extends Context {
+  static fieldType = 'radio-option'
+  static type = 'radio-option'
+  static displayName = 'Radio Option'
+  static returnTypes = [NUMBER, TEXT]
+  static matchTypes = [NUMBER, TEXT]
 
-  static async inflate (ctx, deflated, parent) {
-    return {...deflated, schema: parent.data.schema[deflated.formKey]}
+  static async inflate (ctx, deflated) {
+    return deflated.data
   }
 
   constructor (parent, returnTypes, data, ctx) {
     super(parent, returnTypes, data, ctx)
     this.validate(data)
-    this.name = data.label
-    this.formKey = data.formKey
+    this.name = data.text
   }
 
   getChildren = async filter => []
@@ -35,26 +36,28 @@ export default class CMField extends Context {
   }
 
   deflate (valueList = []) {
-    const { parent, type, name, data } = this
+    const { data, parent, type, name } = this
     if (parent) parent.deflate(valueList)
-    valueList.push({ type, name, formKey: data.formKey, label: data.label, requiresParent: true })
+    valueList.push({ type, name, requiresParent: false, data })
     return valueList
   }
 
   /**
-   * Expect the parent form to have provided a document containing values
    * @param {Object} valueMap a map of parent's output
    */
   async getValue (valueMap = {}) {
-    throw new Error('Unimplemented')
+    const { data, parent } = this
+    if (parent) await parent.getValue(valueMap)
+    valueMap[RadioOption.type] = data
+    return data.key
   }
 
   // --- Utility Functions ---
 
   validate (data) {
-    if (!data || !data.type || !data.formKey || !data.label) {
+    if (!data || !data.key || !data.text) {
       throw new Error(
-        'Cannot create a CM Field Context without propperly formatted form data'
+        `Invalid RadioOption value: ${data}`
       )
     }
   }

--- a/src/extensions/contexts/cm-forms/radio-option.spec.js
+++ b/src/extensions/contexts/cm-forms/radio-option.spec.js
@@ -1,0 +1,99 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+import RadioOption from './radio-option'
+
+describe('RadioOption', () => {
+  let parent, ctx, data, radioOption
+  beforeEach(() => {
+    parent = {
+      deflate: jest.fn(),
+      getValue: jest.fn()
+    }
+    ctx = 'some ctx object'
+    data = { type: 'foo', key: 'bar', label: 'baz', text: 'stuff' }
+    radioOption = new RadioOption(parent, '*', data, ctx)
+  })
+
+  it('inflates', async () => {
+    const val = await RadioOption.inflate(null, { data })
+    expect(val).toEqual(data)
+  })
+
+  describe('isEqual', () => {
+    it('returns false if context is falsy', () => {
+      expect(radioOption.isEqual()).toBe(false)
+    })
+
+    it('returns false if context.data is falsy', () => {
+      expect(radioOption.isEqual({})).toBe(false)
+    })
+
+    it('returns true if context.data is equal to this.data', () => {
+      expect(radioOption.isEqual({ data })).toBe(true)
+    })
+  })
+
+  it('deflates with no parent', () => {
+    const valueList = []
+    radioOption = new RadioOption(undefined, '*', data, ctx)
+    radioOption.deflate(valueList)
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: RadioOption.type,
+      name: data.text,
+      data,
+      requiresParent: false
+    })
+  })
+
+  it('deflates with parent', () => {
+    const valueList = radioOption.deflate()
+    expect(parent.deflate).toHaveBeenCalled()
+    expect(valueList.length).toBe(1)
+    expect(valueList[0]).toEqual({
+      type: RadioOption.type,
+      name: data.text,
+      data,
+      requiresParent: false
+    })
+  })
+
+  describe('getValue', () => {
+    it('return a key and adds data to the valueMap', async () => {
+      const valueMap = {}
+      const value = await radioOption.getValue(valueMap)
+      expect(value).toBe('bar')
+      expect(valueMap[RadioOption.type]).toBe(data)
+    })
+    it('still works as normal even if parent is not set', async () => {
+      radioOption = new RadioOption(undefined, '*', data, ctx)
+      const valueMap = {}
+      const value = await radioOption.getValue(valueMap)
+      expect(value).toBe('bar')
+      expect(valueMap[RadioOption.type]).toBe(data)
+    })
+  })
+
+  describe('validate', () => {
+    it('errors if data is falsy', () => {
+      expect(() => {
+        radioOption.validate()
+      }).toThrow()
+    })
+    it('errors if data.key is falsy', () => {
+      expect(() => {
+        radioOption.validate({ })
+      }).toThrow()
+    })
+  })
+
+  it('is a leaf', () => {
+    expect(radioOption.isLeaf()).toBe(true)
+  })
+})

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -13,6 +13,7 @@ import CMFieldTextInput from './contexts/cm-forms/field-text-input'
 import CMFieldCoreGroupTypeahead from './contexts/cm-forms/field-core-group-typeahead'
 import CMFieldCoreGroupMultiselect from './contexts/cm-forms/field-core-group-multiselect'
 import CMFieldRadioButton from './contexts/cm-forms/field-radio-button'
+import CMFieldCheckbox from './contexts/cm-forms/field-checkbox'
 import RadioOption from './contexts/cm-forms/radio-option'
 import CMFieldTextArea from './contexts/cm-forms/field-text-area'
 import cmAPI from './api/cm'
@@ -24,6 +25,7 @@ export const contexts = [
   CMFieldCoreGroupTypeahead,
   CMFieldCoreGroupMultiselect,
   CMFieldRadioButton,
+  CMFieldCheckbox,
   RadioOption,
   CMFieldTextArea
 ]

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -12,6 +12,7 @@ import CMForm from './contexts/cm-forms/form'
 import CMFieldTextInput from './contexts/cm-forms/field-text-input'
 import CMFieldCoreGroupTypeahead from './contexts/cm-forms/field-core-group-typeahead'
 import CMFieldRadioButton from './contexts/cm-forms/field-radio-button'
+import RadioOption from './contexts/cm-forms/radio-option'
 import CMFieldTextArea from './contexts/cm-forms/field-text-area'
 import cmAPI from './api/cm'
 
@@ -21,6 +22,7 @@ export const contexts = [
   CMFieldTextInput,
   CMFieldCoreGroupTypeahead,
   CMFieldRadioButton,
+  RadioOption,
   CMFieldTextArea
 ]
 

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -1,16 +1,59 @@
-module.exports.config = {
-  apis: {
-    cm: {
-      serviceAgent: {
-        secret: '4439ew8uf23weausdfljho4iuweahfs7023das',
-        expire: 60,
-        header: 'Authorization',
-        tokenPrefix: 'Bearer ',
-        disableSingleUse: true
-      },
-      protocol: 'https',
-      host: 'kuali.co',
-      forms: { v0: '/api/cm' }
-    }
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import Promise from 'bluebird'
+
+import CMForms from './contexts/cm-forms'
+import CMForm from './contexts/cm-forms/form'
+import CMFieldTextInput from './contexts/cm-forms/field-text-input'
+import CMFieldCoreGroupTypeahead from './contexts/cm-forms/field-core-group-typeahead'
+import cmAPI from './api/cm'
+
+export const contexts = [
+  CMForms,
+  CMForm,
+  CMFieldTextInput,
+  CMFieldCoreGroupTypeahead
+]
+
+export const rootContexts = [
+  { type: CMForms }
+]
+
+export const apis = [
+  cmAPI
+]
+
+export function getValue (wfContext, context, valueMap = {}) {
+  switch (context.type) {
+    case 'cmformfill':
+      return getCMFormfillValue(wfContext, context, valueMap)
+    default:
+      return false
+  }
+}
+
+async function getCMFormfillValue (wfContext, formContext, valueMap) {
+  const { definition, instance, instances } = valueMap
+  const formId = formContext.data._id
+  const { step: definitionStep } = wfContext.findDefinitionStep(formId, definition)
+  const instanceStep = wfContext.findInstanceStep(
+    definitionStep._id.toString(),
+    instance,
+    instances
+  )
+  const responses = await Promise.props({
+    schema: wfContext.ctx.apis.cm.schema(formId),
+    item: wfContext.ctx.apis.cm.getItem(formId, instanceStep.meta.form._id)
+  })
+  return {
+    ...responses,
+    definitionStep,
+    instanceStep,
+    handlerUrl: `/cm/#/${formId}/view/${responses.item.id}`
   }
 }

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -38,7 +38,7 @@ export const apis = [
   cmAPI
 ]
 
-export function getValue (wfContext, context, valueMap = {}) {
+export async function getValue (wfContext, context, valueMap = {}) {
   switch (context.type) {
     case 'cmformfill':
       return getCMFormfillValue(wfContext, context, valueMap)

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -11,6 +11,7 @@ import CMForms from './contexts/cm-forms'
 import CMForm from './contexts/cm-forms/form'
 import CMFieldTextInput from './contexts/cm-forms/field-text-input'
 import CMFieldCoreGroupTypeahead from './contexts/cm-forms/field-core-group-typeahead'
+import CMFieldCoreGroupMultiselect from './contexts/cm-forms/field-core-group-multiselect'
 import CMFieldRadioButton from './contexts/cm-forms/field-radio-button'
 import RadioOption from './contexts/cm-forms/radio-option'
 import CMFieldTextArea from './contexts/cm-forms/field-text-area'
@@ -21,6 +22,7 @@ export const contexts = [
   CMForm,
   CMFieldTextInput,
   CMFieldCoreGroupTypeahead,
+  CMFieldCoreGroupMultiselect,
   CMFieldRadioButton,
   RadioOption,
   CMFieldTextArea

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -11,13 +11,17 @@ import CMForms from './contexts/cm-forms'
 import CMForm from './contexts/cm-forms/form'
 import CMFieldTextInput from './contexts/cm-forms/field-text-input'
 import CMFieldCoreGroupTypeahead from './contexts/cm-forms/field-core-group-typeahead'
+import CMFieldRadioButton from './contexts/cm-forms/field-radio-button'
+import CMFieldTextArea from './contexts/cm-forms/field-text-area'
 import cmAPI from './api/cm'
 
 export const contexts = [
   CMForms,
   CMForm,
   CMFieldTextInput,
-  CMFieldCoreGroupTypeahead
+  CMFieldCoreGroupTypeahead,
+  CMFieldRadioButton,
+  CMFieldTextArea
 ]
 
 export const rootContexts = [

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -1,0 +1,16 @@
+module.exports.config = {
+  apis: {
+    cm: {
+      serviceAgent: {
+        secret: '4439ew8uf23weausdfljho4iuweahfs7023das',
+        expire: 60,
+        header: 'Authorization',
+        tokenPrefix: 'Bearer ',
+        disableSingleUse: true
+      },
+      protocol: 'https',
+      host: 'kuali.co',
+      forms: { v0: '/api/cm' }
+    }
+  }
+}

--- a/src/extensions/index.spec.js
+++ b/src/extensions/index.spec.js
@@ -1,0 +1,48 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import { getValue } from './index'
+
+describe('extensions/index', () => {
+  describe('getValue', () => {
+    it('returns false if context.type is not a custom value', async () => {
+      const value = await getValue({}, { type: 'something unexpected' })
+      expect(value).toBe(
+        false
+      )
+    })
+
+    it('handles a cmformfill context.type', async () => {
+      const findDefinitionStep = jest
+        .fn()
+        .mockReturnValue({ step: { _id: 'step123' } })
+      const instanceStep = { meta: { form: { _id: 'instanceStep123' } } }
+      const findInstanceStep = jest.fn().mockReturnValue(instanceStep)
+      const schema = jest.fn().mockReturnValue('some schema object')
+      const item = { id: 'item123' }
+      const getItem = jest.fn().mockReturnValue(item)
+      const mockWFContext = {
+        findDefinitionStep,
+        findInstanceStep,
+        ctx: { apis: { cm: { schema, getItem } } }
+      }
+      const mockContext = { type: 'cmformfill', data: { _id: 'courses' } }
+      const value = await getValue(mockWFContext, mockContext)
+      expect(findDefinitionStep).toHaveBeenCalled()
+      expect(findInstanceStep).toHaveBeenCalled()
+      expect(schema).toHaveBeenCalled()
+      expect(getItem).toHaveBeenCalled()
+      expect(value).toEqual({
+        schema: 'some schema object',
+        item,
+        definitionStep: { _id: 'step123' },
+        instanceStep,
+        handlerUrl: '/cm/#/courses/view/item123'
+      })
+    })
+  })
+})

--- a/src/extensions/return-types.js
+++ b/src/extensions/return-types.js
@@ -1,0 +1,12 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+
+export const CMFORM = 'cmform'
+export const returnTypes = {
+  forms: [CMFORM]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1928,6 +1928,12 @@ first-chunk-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
 
+first-chunk-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
+  dependencies:
+    readable-stream "^2.0.2"
+
 flagged-respawn@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-0.3.2.tgz#ff191eddcd7088a675b2610fffc976be9b8074b5"
@@ -2099,6 +2105,13 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob-parent@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
 glob-stream@^3.1.5:
   version "3.1.18"
   resolved "https://registry.yarnpkg.com/glob-stream/-/glob-stream-3.1.18.tgz#9170a5f12b790306fdfe598f313f8f7954fd143b"
@@ -2253,7 +2266,7 @@ gulp-postcss@7.0.0:
     postcss-load-config "^1.2.0"
     vinyl-sourcemaps-apply "^0.2.1"
 
-gulp-util@^3.0.0, gulp-util@^3.0.8:
+gulp-util@^3.0.0, gulp-util@^3.0.7, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -2275,6 +2288,21 @@ gulp-util@^3.0.0, gulp-util@^3.0.8:
     replace-ext "0.0.1"
     through2 "^2.0.0"
     vinyl "^0.5.0"
+
+gulp-watch@^4.3.11:
+  version "4.3.11"
+  resolved "https://registry.yarnpkg.com/gulp-watch/-/gulp-watch-4.3.11.tgz#162fc563de9fc770e91f9a7ce3955513a9a118c0"
+  dependencies:
+    anymatch "^1.3.0"
+    chokidar "^1.6.1"
+    glob-parent "^3.0.1"
+    gulp-util "^3.0.7"
+    object-assign "^4.1.0"
+    path-is-absolute "^1.0.1"
+    readable-stream "^2.2.2"
+    slash "^1.0.0"
+    vinyl "^1.2.0"
+    vinyl-file "^2.0.0"
 
 gulp@3.9.1:
   version "3.9.1"
@@ -2525,6 +2553,10 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
+is-extglob@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
@@ -2550,6 +2582,12 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
+
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  dependencies:
+    is-extglob "^2.1.0"
 
 is-my-json-valid@^2.10.0:
   version "2.16.1"
@@ -3669,6 +3707,10 @@ parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -4470,6 +4512,13 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-bom-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz#f87db5ef2613f6968aa545abfe1ec728b6a829ca"
+  dependencies:
+    first-chunk-stream "^2.0.0"
+    strip-bom "^2.0.0"
+
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -4733,6 +4782,17 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vinyl-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vinyl-file/-/vinyl-file-2.0.0.tgz#a7ebf5ffbefda1b7d18d140fcb07b223efb6751a"
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.3.0"
+    pinkie-promise "^2.0.0"
+    strip-bom "^2.0.0"
+    strip-bom-stream "^2.0.0"
+    vinyl "^1.1.0"
+
 vinyl-fs@^0.3.0:
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-0.3.14.tgz#9a6851ce1cac1c1cea5fe86c0931d620c2cfa9e6"
@@ -4762,6 +4822,14 @@ vinyl@^0.4.0:
 vinyl@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-0.5.3.tgz#b0455b38fc5e0cf30d4325132e461970c2091cde"
+  dependencies:
+    clone "^1.0.0"
+    clone-stats "^0.0.1"
+    replace-ext "0.0.1"
+
+vinyl@^1.1.0, vinyl@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-1.2.0.tgz#5c88036cf565e5df05558bfc911f8656df218884"
   dependencies:
     clone "^1.0.0"
     clone-stats "^0.0.1"


### PR DESCRIPTION
This PR mainly adds support for CM Forms and Fields as an additional Form Context.  It also includes the following fixes/enhancements:
- Added ability to "gulp watch" for changes and recomplie
- Enhanced several contexts (mainly global-groups and global-users) to work with CM fields and generally be more flexible while (hopefully) maintaining existing functionality.
- Minor changes to support several of the features added by https://github.com/KualiCo/cor-workflows-api/pull/3