### PR TITLE
Improved Error Handling in User Context

### DIFF
--- a/src/data-dictionary/context-utils.js
+++ b/src/data-dictionary/context-utils.js
@@ -175,20 +175,12 @@ export class ContextUtil {
    */
   async inflate (deflated, returnTypes = '*') {
     const { scope } = this
-    const promises = deflated.map(d => {
-      if (d.requiresParent) return
-      return this.contextMap[d.type].inflate(this, d, undefined, scope)
-    })
-    const datas = await Promise.all(promises)
     const contexts = []
-    for (let i = 0; i < datas.length; i++) {
+    for (let i = 0; i < deflated.length; i++) {
       const defd = deflated[i]
-      let data = datas[i]
-      const Context = this.contextMap[defd.type]
       const parent = i > 0 ? contexts[i - 1] : undefined
-      if (defd.requiresParent) {
-        data = datas[i] = await Context.inflate(this, defd, parent, scope)
-      }
+      const Context = this.contextMap[defd.type]
+      let data = await Context.inflate(this, defd, parent, scope)
       const ctx = Context.type === this.Root.type
         ? this.root || new Root(parent, returnTypes, data, this)
         : new Context(parent, returnTypes, data, this)

--- a/src/data-dictionary/global-groups/group.js
+++ b/src/data-dictionary/global-groups/group.js
@@ -65,7 +65,7 @@ export default class Group extends Context {
   }
 
   static async inflate (ctx, deflated) {
-    return deflated
+    return deflated.data
   }
 
   deflate (valueList = []) {

--- a/src/data-dictionary/global-groups/group.js
+++ b/src/data-dictionary/global-groups/group.js
@@ -84,5 +84,6 @@ export default class Group extends Context {
   async getValue (valueMap = {}) {
     super.getValue(valueMap)
     valueMap.groupId = this.data.id
+    return this.data
   }
 }

--- a/src/data-dictionary/global-users/user.js
+++ b/src/data-dictionary/global-users/user.js
@@ -47,15 +47,18 @@ export default class User extends Context {
   async getValue (valueMap = {}) {
     const { parent } = this
     if (parent) await parent.getValue(valueMap)
-    const user = Object.assign(
-      {
-        toString: function () {
-          return this.displayName
-        }
-      },
-      this.data
-    )
-    valueMap.user = { value: user }
-    return user
+    if (this.data) {
+      const user = Object.assign(
+        {
+          toString: function () {
+            return this.displayName
+          }
+        },
+        this.data
+      )
+      valueMap.user = { value: user }
+      return user
+    }
+    return undefined
   }
 }

--- a/src/extensions/contexts/cm-forms/field-core-group-multiselect.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-multiselect.js
@@ -55,7 +55,14 @@ export default class FieldCoreGroupMultiselect extends CMField {
   }
 
   async getValue (valueMap = {}) {
-    super.getValue(valueMap)
-    valueMap.formKey = this.data.formKey
+    const { parent } = this
+    if (parent) {
+      const parentData = await parent.getValue(valueMap)
+      valueMap.formKey = this.data.formKey
+      const {formKey} = valueMap
+      const id = parentData.item[formKey]
+      return this.ctx.apis.groups.get(id)
+
+    }
   }
 }

--- a/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
@@ -55,7 +55,13 @@ export default class FieldCoreGroupTypeahead extends CMField {
   }
 
   async getValue (valueMap = {}) {
-    super.getValue(valueMap)
-    valueMap.formKey = this.data.formKey
+    const { parent } = this
+    if (parent) {
+      const parentData = await parent.getValue(valueMap)
+      valueMap.formKey = this.data.formKey
+      const {formKey} = valueMap
+      const id = parentData.item[formKey]
+      return this.ctx.apis.groups.get(id)
+    }
   }
 }

--- a/src/extensions/contexts/cm-forms/field-core-user-typeahead.js
+++ b/src/extensions/contexts/cm-forms/field-core-user-typeahead.js
@@ -1,0 +1,32 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import CMField from './field'
+import User from '../../../data-dictionary/global-users/user'
+import { USER, TEXT } from '../../../data-dictionary/return-types'
+
+export default class FieldCoreUserTypeahead extends CMField {
+  static fieldType = 'UserTypeahead'
+  static type = 'cm-field-core-user-typeahead'
+  static treatAsType = User.type
+  static returnTypes = [USER, TEXT]
+  static matchTypes = [USER, TEXT]
+
+  async getValue (valueMap = {}) {
+    const { data, parent } = this
+    if (parent) {
+      const parentData = await parent.getValue(valueMap)
+      valueMap.formKey = this.data.formKey
+      const {formKey} = valueMap
+      const userId = parentData.item[formKey]
+      const user = await this.ctx.apis.users.getUser(userId)
+      user.toString = function () { return this.displayName || this.username }
+      valueMap.field = { value: user }
+      return user
+    }
+  }
+}

--- a/src/extensions/contexts/cm-forms/field.js
+++ b/src/extensions/contexts/cm-forms/field.js
@@ -35,9 +35,9 @@ export default class CMField extends Context {
   }
 
   deflate (valueList = []) {
-    const { parent, type, name, data } = this
+    const { parent, type, name, data, treatAsType } = this
     if (parent) parent.deflate(valueList)
-    valueList.push({ type, name, formKey: data.formKey, label: data.label, requiresParent: true })
+    valueList.push({ type, treatAsType, name, formKey: data.formKey, label: data.label, requiresParent: true })
     return valueList
   }
 

--- a/src/extensions/contexts/cm-forms/field.js
+++ b/src/extensions/contexts/cm-forms/field.js
@@ -41,11 +41,19 @@ export default class CMField extends Context {
   }
 
   /**
-   * Expect the parent form to have provided a document containing values
+   * Expect the parent form to have provided an item containing form values
    * @param {Object} valueMap a map of parent's output
    */
   async getValue (valueMap = {}) {
-    throw new Error('Unimplemented')
+    const { data, parent } = this
+    if (parent) {
+      const parentData = await parent.getValue(valueMap)
+      if (parentData.item) {
+        const value = parentData.item[data.formKey]
+        valueMap.field = { value }
+        return value
+      }
+    }
   }
 
   // --- Utility Functions ---

--- a/src/extensions/contexts/cm-forms/form.js
+++ b/src/extensions/contexts/cm-forms/form.js
@@ -13,6 +13,7 @@ import { CMFORM } from '../../return-types'
 import CMFieldTextInput from './field-text-input'
 import CMFieldCoreGroupTypeahead from './field-core-group-typeahead'
 import CMFieldCoreGroupMultiselect from './field-core-group-multiselect'
+import CMFieldUserTypeahead from './field-core-user-typeahead'
 import CMFieldRadioButton from './field-radio-button'
 import CMFieldCheckbox from './field-checkbox'
 import CMFieldTextArea from './field-text-area'
@@ -21,6 +22,7 @@ const fieldList = {
   CMFieldTextInput,
   CMFieldCoreGroupTypeahead,
   CMFieldCoreGroupMultiselect,
+  CMFieldUserTypeahead,
   CMFieldRadioButton,
   CMFieldCheckbox,
   CMFieldTextArea

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -12,6 +12,7 @@ import CMForm from './contexts/cm-forms/form'
 import CMFieldTextInput from './contexts/cm-forms/field-text-input'
 import CMFieldCoreGroupTypeahead from './contexts/cm-forms/field-core-group-typeahead'
 import CMFieldCoreGroupMultiselect from './contexts/cm-forms/field-core-group-multiselect'
+import CMFieldCoreUserTypeahead from './contexts/cm-forms/field-core-user-typeahead'
 import CMFieldRadioButton from './contexts/cm-forms/field-radio-button'
 import CMFieldCheckbox from './contexts/cm-forms/field-checkbox'
 import RadioOption from './contexts/cm-forms/radio-option'
@@ -24,6 +25,7 @@ export const contexts = [
   CMFieldTextInput,
   CMFieldCoreGroupTypeahead,
   CMFieldCoreGroupMultiselect,
+  CMFieldCoreUserTypeahead,
   CMFieldRadioButton,
   CMFieldCheckbox,
   RadioOption,


### PR DESCRIPTION
Right now there is an error in workflow where the call to /api/v1/users/:id is failing.  This is causing unexpected behavior and I'm taking advantage of this error to turn that unexpected behavior into expected behavior so that if something similar happens again in the future we will fail gracefully.