### PR TITLE
Handle blank user field in forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuali-cor-workflows-common",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Workflows code common to both client and server",
   "author": "Kuali Core Team",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/data-dictionary/global-forms/field-core-user-typeahead.js
+++ b/src/data-dictionary/global-forms/field-core-user-typeahead.js
@@ -5,6 +5,7 @@
  * You should have received a copy of the Kuali, Inc. Pre-Release License
  * Agreement with this file. If not, please write to license@kuali.co.
  */
+import { get } from 'lodash'
 import Field from './field'
 import { USER, TEXT } from '../return-types'
 
@@ -28,9 +29,11 @@ export default class FieldCoreUserTypeahead extends Field {
     if (parent) await parent.getValue(valueMap)
     if (!valueMap.formfill || !valueMap.formfill.document) return
     const { document } = valueMap.formfill
-    const userId = document.data[data.formKey].id
-    const user = await this.ctx.apis.users.getUser(userId)
-    user.toString = function () { return this.displayName || this.username }
+    const userId = get(document, `data.${data.formKey}.id`)
+    const user = userId ? await this.ctx.apis.users.getUser(userId) : {}
+    user.toString = function () {
+      return this.displayName || this.username
+    }
     valueMap.field = { value: user }
     return user
   }

--- a/src/data-dictionary/global-forms/field-core-user-typeahead.spec.js
+++ b/src/data-dictionary/global-forms/field-core-user-typeahead.spec.js
@@ -13,7 +13,7 @@ import FieldTest, { mockFieldData } from '../../test/utils/fields'
 FieldTest(UserTypeahead, [USER, TEXT], [USER, TEXT], true)
 
 describe('getValue', () => {
-  let data, typeahead, ctx, user
+  let data, typeahead, ctx, user, parent, passedMap
   beforeEach(() => {
     data = mockFieldData()
     user = { name: 'a user' }
@@ -24,19 +24,25 @@ describe('getValue', () => {
         }
       }
     }
-    typeahead = new UserTypeahead(null, null, data, ctx)
-  })
-
-  it('should can the parent getValue', async () => {
-    let passedMap
-    const parent = {
+    parent = {
       getValue: jest.fn().mockImplementation(map => {
         passedMap = { ...map }
       })
     }
-    typeahead.parent = parent
+    typeahead = new UserTypeahead(parent, null, data, ctx)
+  })
+
+  it('should can the parent getValue', async () => {
     await typeahead.getValue()
     expect(passedMap).toMatchObject({})
+  })
+
+  it('handles empty userId value in form', async () => {
+    const user = await typeahead.getValue({
+      formfill: { document: { data: {} } }
+    })
+    expect(ctx.apis.users.getUser).not.toHaveBeenCalled()
+    expect(user.toString()).toBeUndefined()
   })
 
   it('should return nothing if formfill and document are not present', async () => {

--- a/src/extensions/contexts/cm-forms/field-core-user-typeahead.js
+++ b/src/extensions/contexts/cm-forms/field-core-user-typeahead.js
@@ -21,11 +21,10 @@ export default class FieldCoreUserTypeahead extends CMField {
     if (parent) {
       const parentData = await parent.getValue(valueMap)
       valueMap.formKey = data.formKey
-      const {formKey} = valueMap
+      const { formKey } = valueMap
       const userId = parentData.item[formKey]
-      const user = await this.ctx.apis.users.getUser(userId)
+      const user = userId ? await this.ctx.apis.users.getUser(userId) : {}
       user.toString = function () {
-        console.log({ thiz: this })
         return this.displayName || this.username
       }
       valueMap.field = { value: user }

--- a/src/extensions/contexts/cm-forms/field-core-user-typeahead.spec.js
+++ b/src/extensions/contexts/cm-forms/field-core-user-typeahead.spec.js
@@ -33,4 +33,12 @@ describe('Data Dictionary: Field: Core User Typeahead', () => {
     expect(valueMap.formKey).toBe('bar')
     expect(user.toString()).toEqual('x')
   })
+
+  it('handles empty userId value in form', async () => {
+    data = { type: 'foo', formKey: 'missing', label: 'missing' }
+    field = new UserTypeahead(parent, '*', data, ctx)
+    const user = await field.getValue({})
+    expect(ctx.apis.users.getUser).not.toHaveBeenCalled()
+    expect(user.toString()).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Currently, if a workflow step is set up to route to a user based on a form field, it will blow up if that form field happens to be empty.

Instead, this PR makes it so that is doesn't blow up but instead returns an empty object.  That empty object then can be used by the API to automatically skip the step if the field is blank (see https://github.com/KualiCo/cor-workflows-api/pull/18) or do something else (if that's what someone wants to do at some point).
  