### PR TITLE
Split up the Rule class

### DIFF
--- a/src/rules/compound-rule.js
+++ b/src/rules/compound-rule.js
@@ -1,0 +1,57 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import _ from 'lodash'
+import { evaluate as operatorEvaluate } from '../data-dictionary/operators/index'
+
+export const LOGICAL_OPERATORS = {
+  AND: 'and',
+  OR: 'or'
+}
+
+const expressionIsTrue = evaluatedExpression => evaluatedExpression === true
+
+const logicalOperator = _.curry(
+  (logicalIterator, comparator, evaluatedExpressions) =>
+    logicalIterator(evaluatedExpressions, comparator)
+)
+
+const LOGICAL_OPERATOR_EVALUATORS = {
+  [LOGICAL_OPERATORS.AND]: logicalOperator(_.every, expressionIsTrue),
+  [LOGICAL_OPERATORS.OR]: logicalOperator(_.some, expressionIsTrue)
+}
+
+export default class CompoundRule {
+  constructor (rule, resolver, ruleEvaluator = operatorEvaluate) {
+    this.rule = rule
+    this.resolver = resolver
+    this.ruleEvaluator = ruleEvaluator
+  }
+
+  async evaluate (Rule) {
+    const { logicalOperator, expressions } = this.rule
+    if (!_.has(LOGICAL_OPERATORS, _.toUpper(logicalOperator))) {
+      throw new Error(`Unknown logical operator "${logicalOperator}"`)
+    }
+
+    const promises = expressions.map(expression => {
+      const rule = new Rule(expression, this.resolver)
+      return rule.evaluate()
+    })
+    const evaluatedExpressions = await Promise.all(promises)
+    const operatorFn = LOGICAL_OPERATOR_EVALUATORS[logicalOperator]
+    return operatorFn(evaluatedExpressions)
+  }
+
+  toJSON (Rule) {
+    const { logicalOperator, expressions } = this.rule
+    return {
+      logicalOperator,
+      expressions: expressions.map(expression => new Rule(expression).toJSON())
+    }
+  }
+}

--- a/src/rules/rule.spec.js
+++ b/src/rules/rule.spec.js
@@ -8,12 +8,16 @@ describe('Rule', () => {
     const fn = () => {}
     const single = new Rule({ left: true, operator: 'is true' }, fn)
     expect(single).toHaveProperty('rule')
-    expect(single).toHaveProperty('resolver')
     expect(single).toHaveProperty('type', Rule.TYPES.SINGLE)
+    expect(single.rule.constructor.name).toBe('SingularRule')
+    expect(single.rule).toHaveProperty('rule')
+    expect(single.rule).toHaveProperty('resolver')
     const compound = new Rule({ logicalOperator: true, expressions: true }, fn)
     expect(compound).toHaveProperty('rule')
-    expect(compound).toHaveProperty('resolver')
     expect(compound).toHaveProperty('type', Rule.TYPES.COMPOUND)
+    expect(compound.rule.constructor.name).toBe('CompoundRule')
+    expect(compound.rule).toHaveProperty('rule')
+    expect(compound.rule).toHaveProperty('resolver')
   })
 
   test('errors if missing parameters', () => {

--- a/src/rules/singular-rule.js
+++ b/src/rules/singular-rule.js
@@ -1,0 +1,157 @@
+/* Copyright © 2016 Kuali, Inc. - All Rights Reserved
+ * You may use and modify this code under the terms of the Kuali, Inc.
+ * Pre-Release License Agreement. You may not distribute it.
+ *
+ * You should have received a copy of the Kuali, Inc. Pre-Release License
+ * Agreement with this file. If not, please write to license@kuali.co.
+ */
+import _ from 'lodash'
+import ctx from '../data-dictionary/context-utils'
+import dataTypes from '../data-dictionary/data-types'
+import { getOperator, isUnary } from '../data-dictionary/operators'
+import {
+  evaluate as operatorEvaluate,
+  isOperationSupported,
+  supportedRightTypes
+} from '../data-dictionary/operators/index'
+import { coerce } from '../data-dictionary/coerce'
+import util from 'util'
+
+export default class SingularRule {
+  constructor (rule, resolver, ruleEvaluator = operatorEvaluate) {
+    this.rule = rule
+    this.resolver = resolver
+    this.structuredOperator = getOperator(this.rule.operator)
+    this.ruleEvaluator = ruleEvaluator
+  }
+
+  compareAsIs (left, right) {
+    return this.ruleEvaluator(
+      this.structuredOperator,
+      _.get(left, ['context', 'treatAsType']),
+      _.get(left, 'value'),
+      _.get(right, ['context', 'treatAsType']),
+      _.get(right, 'value')
+    )
+  }
+
+  coerceAndCompare (left, right) {
+    const comparable = this.findComparableTypes(
+      left,
+      this.structuredOperator,
+      right
+    )
+    const response = this.findBestResponse(
+      comparable,
+      left,
+      this.structuredOperator,
+      right
+    )
+    return response
+  }
+
+  async evaluate (_Rule) {
+    try {
+      const promises = [this.resolver(this.rule.left)]
+      if (this.rule.right) {
+        promises.push(this.resolver(this.rule.right))
+      }
+      const [left, right] = await Promise.all(promises)
+      if (
+        isOperationSupported(
+          this.structuredOperator,
+          _.get(left, ['context', 'treatAsType']),
+          _.get(right, ['context', 'treatAsType'])
+        )
+      ) {
+        return this.compareAsIs(left, right)
+      }
+      return this.coerceAndCompare(left, right)
+    } catch (err) {
+      console.log('Error finding comparable types.')
+      console.log('rule ->', JSON.stringify(this.rule, null, 2))
+      console.log(err)
+      throw err
+    }
+  }
+
+  findComparableTypes (left, operator, right) {
+    try {
+      return _.flatMapDeep(left.types, leftTypeName => {
+        // TODO what if we don't get a leftType here?
+        const leftType = _.get(dataTypes, leftTypeName, {})
+        if (isUnary(operator)) {
+          return { left: leftType }
+        }
+
+        // TODO what if left type doesn't have support for this operator?
+        const operatorSupportedRightTypes = supportedRightTypes(
+          operator,
+          leftTypeName
+        )
+        const rightValueSupportedTypes = _.get(right, 'types', [])
+        const intersectingRightTypes = _.intersection(
+          operatorSupportedRightTypes,
+          rightValueSupportedTypes
+        )
+        return _.map(intersectingRightTypes, rightTypeName => ({
+          left: leftType,
+          right: _.get(dataTypes, rightTypeName, {}) // TODO what if we don't get a rightType here?
+        }))
+      })
+    } catch (err) {
+      console.log('Error finding comparable types.')
+      console.log('left ->')
+      console.log(util.inspect(left, { depth: 5 }))
+      console.log('operator ->')
+      console.log(operator)
+      console.log('right ->')
+      console.log(util.inspect(right, { depth: 5 }))
+    }
+  }
+
+  findBestResponse (comparables, left, operator, right) {
+    for (let i = 0; i < comparables.length; i++) {
+      try {
+        const comparable = comparables[i]
+        const leftTargetType = _.get(comparable, 'left.TYPE')
+        const rightTargetType = _.get(comparable, 'right.TYPE')
+        const coercedLeft = coerce(
+          _.get(left, ['context', 'treatAsType']),
+          leftTargetType,
+          _.get(left, 'value')
+        )
+        const coercedRight = right
+          ? _.coerce(
+            _.get(right, ['context', 'treatAsType']),
+            rightTargetType,
+            _.get(right, 'value')
+          )
+          : undefined
+
+        return this.ruleEvaluator(
+          operator,
+          leftTargetType,
+          coercedLeft,
+          rightTargetType,
+          coercedRight
+        )
+      } catch (error) {
+        console.log(`[${operator}] Operation Failed:`, error)
+        const isLastComparable = comparables.length === i + 1
+        if (isLastComparable) {
+          throw error
+        }
+      }
+    }
+  }
+
+  toJSON (_Rule) {
+    const { left, operator, right } = this.rule
+    return {
+      left: ctx.deflate(left),
+      operator,
+      right: ctx.deflate(right)
+    }
+  }
+}


### PR DESCRIPTION
As soon as I saw the PR from Kip on conditionally adding the `structuredOperator` property if the
rule was singular I knew they should be split up.

The Rule type delegates to SingularRule or CompoundRule depending on the format of the incoming
rule data object. No interfaces should have been harmed in the creating of this Pull Request.