### PR TITLE
Fixes to how Options are handled to support Checkboxes field type in CM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuali-cor-workflows-common",
-  "version": "0.4.29",
+  "version": "0.4.32",
   "description": "Workflows code common to both client and server",
   "author": "Kuali Core Team",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/data-dictionary/data-types/options.js
+++ b/src/data-dictionary/data-types/options.js
@@ -1,11 +1,14 @@
 import * as _ from 'lodash'
-import { OPTIONS, TEXT } from '../return-types'
+import { OPTIONS, TEXT_LIST } from '../return-types'
 
 export const TYPE = OPTIONS
 
 export const COERCIONS = {
   [OPTIONS]: _.identity,
-  [TEXT]: option => _.get(option, 'displayName') || _.get(option, 'name')
+  [TEXT_LIST]: option => _.reduce(option, (res, val, key) => {
+    if (val) res.push(key)
+    return res
+  }, [])
 }
 
 export const CAN_COERCE_TO = _.keys(COERCIONS)

--- a/src/data-dictionary/data-types/options.spec.js
+++ b/src/data-dictionary/data-types/options.spec.js
@@ -1,4 +1,4 @@
-import { TEXT, OPTIONS } from '../return-types'
+import { OPTIONS, TEXT_LIST } from '../return-types'
 import { CAN_COERCE_TO, COERCIONS, TYPE } from './options'
 
 describe('Options Data Type', () => {
@@ -15,30 +15,24 @@ describe('Options Data Type', () => {
       expect(COERCIONS[OPTIONS].length).toBe(1)
     })
 
-    it('can coerce to TEXT', () => {
-      expect(CAN_COERCE_TO).toContain(TEXT)
-      expect(COERCIONS).toHaveProperty(TEXT)
-      expect(COERCIONS[TEXT].length).toBe(1)
+    it('can coerce to TEXT_LIST', () => {
+      expect(CAN_COERCE_TO).toContain(TEXT_LIST)
+      expect(COERCIONS).toHaveProperty(TEXT_LIST)
+      expect(COERCIONS[TEXT_LIST].length).toBe(1)
     })
   })
 
   describe('COERCIONS', () => {
     it('coerces option -> option (e.g. identity)', () => {
-      const option = { displayName: 'Bob' }
+      const option = { happy: true, sad: false }
       const coercedOptions = COERCIONS[OPTIONS](option)
       expect(coercedOptions).toBe(option)
     })
 
-    it("coerces option -> text using the option's displayName", () => {
-      const option = { displayName: 'Bobby', name: 'Robert' }
-      const coercedOptions = COERCIONS[TEXT](option)
-      expect(coercedOptions).toBe(option.displayName)
-    })
-
-    it("coerces option -> text using the option's name when the displayName is not present", () => {
-      const option = { displayName: undefined, name: 'Robert' }
-      const coercedOptions = COERCIONS[TEXT](option)
-      expect(coercedOptions).toBe(option.name)
+    it("coerces option -> text list using the option's keys with true as value", () => {
+      const option = { happy: true, sad: false }
+      const coercedOptions = COERCIONS[TEXT_LIST](option)
+      expect(coercedOptions).toEqual(['happy'])
     })
   })
 })

--- a/src/data-dictionary/operators/is-empty.js
+++ b/src/data-dictionary/operators/is-empty.js
@@ -1,9 +1,10 @@
 import _ from 'lodash'
-import { GROUP_LIST, OPTIONS, TEXT, USER_LIST } from '../return-types'
+import { GROUP_LIST, OPTIONS, TEXT, TEXT_LIST, USER_LIST } from '../return-types'
 
 export default {
   [GROUP_LIST]: _.isEmpty,
   [OPTIONS]: _.isEmpty,
   [TEXT]: _.isEmpty,
-  [USER_LIST]: _.isEmpty
+  [USER_LIST]: _.isEmpty,
+  [TEXT_LIST]: _.isEmpty
 }

--- a/src/data-dictionary/operators/is-not-empty.js
+++ b/src/data-dictionary/operators/is-not-empty.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { GROUP_LIST, OPTIONS, TEXT, USER_LIST } from '../return-types'
+import { GROUP_LIST, OPTIONS, TEXT, TEXT_LIST, USER_LIST } from '../return-types'
 
 const isNotEmpty = _.negate(_.isEmpty)
 
@@ -7,5 +7,6 @@ export default {
   [GROUP_LIST]: isNotEmpty,
   [OPTIONS]: isNotEmpty,
   [TEXT]: isNotEmpty,
-  [USER_LIST]: _.isEmpty
+  [USER_LIST]: isNotEmpty,
+  [TEXT_LIST]: isNotEmpty
 }

--- a/src/data-dictionary/operators/is-not.js
+++ b/src/data-dictionary/operators/is-not.js
@@ -3,10 +3,13 @@ import { OPTIONS, TEXT, USER } from '../return-types'
 
 const inequalityById = (left, right) =>
   _.negate(_.isEqual)(_.get(left, 'id'), _.get(right, 'id'))
+const findNoTrueKey = (left, right) =>
+  !_.find(left, (val, key) => key === right && val === true)
 
 export default {
   [OPTIONS]: {
-    [OPTIONS]: inequalityById
+    [OPTIONS]: inequalityById,
+    [TEXT]: findNoTrueKey
   },
   [TEXT]: {
     [TEXT]: _.negate(_.isEqual)

--- a/src/data-dictionary/operators/is.js
+++ b/src/data-dictionary/operators/is.js
@@ -4,6 +4,9 @@ import { GROUP, NUMBER, OPTIONS, TEXT, USER } from '../return-types'
 const equalityById = (left, right) =>
   _.isEqual(_.get(left, 'id'), _.get(right, 'id'))
 
+const findTrueKey = (left, right) =>
+  !!_.find(left, (val, key) => key === right && val === true)
+
 export default {
   [GROUP]: {
     [GROUP]: equalityById
@@ -12,7 +15,8 @@ export default {
     [NUMBER]: _.isEqual
   },
   [OPTIONS]: {
-    [OPTIONS]: equalityById
+    [OPTIONS]: equalityById,
+    [TEXT]: findTrueKey
   },
   [TEXT]: {
     [TEXT]: _.isEqual

--- a/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
+++ b/src/extensions/contexts/cm-forms/field-core-group-typeahead.js
@@ -10,7 +10,7 @@ import CMField from './field'
 import Category from '../../../data-dictionary/global-categories/category'
 import Role from '../../../data-dictionary/global-roles/role'
 import { GROUP, ROLE, TEXT } from '../../../data-dictionary/return-types'
-import { names, IS, IS_ONE_OF } from '../../../data-dictionary/operators'
+import { names, IS } from '../../../data-dictionary/operators'
 
 export default class FieldCoreGroupTypeahead extends CMField {
   static typeLabel = 'GroupsTypeahead'
@@ -18,7 +18,7 @@ export default class FieldCoreGroupTypeahead extends CMField {
   static treatAsType = GROUP
   static returnTypes = [GROUP, ROLE, TEXT]
   static matchTypes = [GROUP, TEXT]
-  static preferredOperators = names(IS, IS_ONE_OF)
+  static preferredOperators = names(IS)
 
   static async inflate (ctx, deflated, parent) {
     return deflated.data

--- a/src/extensions/contexts/cm-forms/field-options-multiselect.js
+++ b/src/extensions/contexts/cm-forms/field-options-multiselect.js
@@ -8,15 +8,15 @@
 import { compact, isArray } from 'lodash'
 import Promise from 'bluebird'
 import CMField from './field'
-import { OPTIONS } from '../../../data-dictionary/return-types'
+import { TEXT_LIST } from '../../../data-dictionary/return-types'
 import { names, IS_EMPTY, IS_NOT_EMPTY } from '../../../data-dictionary/operators'
 
 export default class FieldOptionsMultiselect extends CMField {
   static typeLabel = 'OptionsMultiselect'
   static type = 'cm-field-options-multiselect'
-  static treatAsType = OPTIONS
-  static returnTypes = [OPTIONS]
-  static matchTypes = [OPTIONS]
+  static treatAsType = TEXT_LIST
+  static returnTypes = [TEXT_LIST]
+  static matchTypes = [TEXT_LIST]
   static preferredOperators = names(IS_NOT_EMPTY, IS_EMPTY)
 
   async getValue (valueMap = {}) {


### PR DESCRIPTION
Also remove "is one of" from GroupTypeahead since it isn't currently supported and changed to OptionsMultiselect to a Text List since CM stores it as a string array.